### PR TITLE
fix(start.sh): smoke works without uv

### DIFF
--- a/start.sh
+++ b/start.sh
@@ -170,7 +170,7 @@ PY
 
   if [[ "$MODE" == "smoke" ]]; then
     echo "[novel-proofer] Running tests..."
-    uv run --frozen --no-sync pytest -q
+    "$PY" -m pytest -q
     echo "[novel-proofer] Tests OK."
     exit 0
   fi


### PR DESCRIPTION
CodeRabbit follow-up: fix `bash start.sh --smoke` when `uv` is not installed.

- In the non-uv fallback branch, smoke mode must not call `uv run`.
- Run tests via the venv Python: `"$PY" -m pytest -q`.

By Codex


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 发布说明

* **测试**
  * 优化了测试执行方式，改进了测试运行流程。

**注：** 此版本主要包含内部测试基础设施的优化调整，对终端用户无明显影响。

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->