### PR TITLE
perf(llm): use httpx connection pooling

### DIFF
--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -52,10 +52,10 @@ novel_proofer/
 │   ├── rules.py       # 确定性文本转换（标点、缩进）
 │   ├── chunking.py    # 按行边界分片（支持文件流式）
 │   └── merge.py       # 分片合并（runner/fixer 复用）
-└── llm/
-    ├── config.py      # LLMConfig、系统提示词
-    ├── client.py      # OpenAI 兼容流式客户端 + 重试逻辑
-    └── think_filter.py # 状态机过滤 <think> 标签
+	└── llm/
+	    ├── config.py      # LLMConfig、系统提示词
+	    ├── client.py      # OpenAI 兼容流式客户端（httpx 连接池）+ 重试逻辑
+	    └── think_filter.py # 状态机过滤 <think> 标签
 ```
 
 | 模块 | 职责 | 关键方法 |

--- a/docs/TESTCASES.md
+++ b/docs/TESTCASES.md
@@ -75,13 +75,13 @@
 | `tests/llm/test_client.py::test_parse_sse_line[event: ping-None]` | SSE 的 `event:` 行不作为数据帧处理，应返回 `None`。 |
 | `tests/llm/test_client.py::test_parse_sse_line[-None]` | 空行应返回 `None`。 |
 | `tests/llm/test_client.py::test_is_loopback_host` | `_is_loopback_host()` 对 `localhost/127.0.0.1` 返回 `True`，其他地址返回 `False`。 |
-| `tests/llm/test_client.py::test_urlopen_uses_no_proxy_for_loopback` | loopback 请求应绕过系统代理：通过 `ProxyHandler({})` 的 opener 执行，而不是直接 `urllib.request.urlopen`。 |
+| `tests/llm/test_client.py::test_httpx_client_for_url_bypasses_env_proxy_for_loopback` | loopback 请求应绕过环境代理：使用 `httpx.Client(trust_env=False)`。 |
 | `tests/llm/test_client.py::test_stream_request_parses_openai_sse` | SSE 流式响应中 `choices[].delta.content` 需按顺序拼接，直到 `[DONE]`。 |
 | `tests/llm/test_client.py::test_stream_request_stops_reading_after_done` | 读到 `[DONE]` 后必须停止继续 `read()`（防止额外 IO/异常）。 |
 | `tests/llm/test_client.py::test_stream_request_should_stop_short_circuits` | `should_stop()` 为真时应短路并抛出终止错误（`LLMError("cancelled")`）。 |
-| `tests/llm/test_client.py::test_stream_request_wraps_url_error` | 网络层 `URLError` 需被包装为 `LLMError("LLM request failed: ...")`。 |
+| `tests/llm/test_client.py::test_stream_request_wraps_url_error` | 网络层 `httpx.RequestError` 需被包装为 `LLMError("LLM request failed: ...")`。 |
 | `tests/llm/test_client.py::test_http_post_json_success` | `_http_post_json()` 能成功解析 JSON 响应体为 Python dict。 |
-| `tests/llm/test_client.py::test_http_post_json_wraps_url_error` | `_http_post_json()` 遇到 `URLError` 需转换为 `LLMError`。 |
+| `tests/llm/test_client.py::test_http_post_json_wraps_url_error` | `_http_post_json()` 遇到 `httpx.RequestError` 需转换为 `LLMError`。 |
 | `tests/llm/test_client.py::test_call_llm_text_resilient_retries_and_succeeds` | `call_llm_text_resilient()` 对可重试错误（如 `HTTP 500`）进行多次尝试并最终成功；同时会调用 `sleep()` 退避。 |
 | `tests/llm/test_client.py::test_call_llm_text_resilient_non_retryable_raises` | 对不可重试错误（如 `HTTP 400`）不应退避重试，直接抛出异常。 |
 | `tests/llm/test_client.py::test_call_llm_text_resilient_with_meta_calls_on_retry` | 带 meta 的重试接口会返回 `retries/last_code/last_msg`，并在重试时触发 `on_retry(idx, code, msg)` 回调。 |

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,6 +4,7 @@ version = "0.1.0"
 requires-python = ">=3.12"
 dependencies = [
   "fastapi>=0.111,<1.0",
+  "httpx>=0.27,<1.0",
   "pydantic>=2.7,<3.0",
   "python-multipart>=0.0.9,<1.0",
   "uvicorn>=0.30,<1.0",
@@ -11,7 +12,6 @@ dependencies = [
 
 [dependency-groups]
 dev = [
-  "httpx>=0.27,<1.0",
   "mypy>=1.19",
   "pytest>=9",
   "pytest-cov>=7",

--- a/requirements.lock.txt
+++ b/requirements.lock.txt
@@ -29,6 +29,7 @@ h11==0.16.0
 httpcore==1.0.9
     # via httpx
 httpx==0.28.1
+    # via novel-proofer
 idna==3.11
     # via
     #   anyio

--- a/uv.lock
+++ b/uv.lock
@@ -307,6 +307,7 @@ version = "0.1.0"
 source = { virtual = "." }
 dependencies = [
     { name = "fastapi" },
+    { name = "httpx" },
     { name = "pydantic" },
     { name = "python-multipart" },
     { name = "uvicorn" },
@@ -314,7 +315,6 @@ dependencies = [
 
 [package.dev-dependencies]
 dev = [
-    { name = "httpx" },
     { name = "mypy" },
     { name = "pytest" },
     { name = "pytest-cov" },
@@ -324,6 +324,7 @@ dev = [
 [package.metadata]
 requires-dist = [
     { name = "fastapi", specifier = ">=0.111,<1.0" },
+    { name = "httpx", specifier = ">=0.27,<1.0" },
     { name = "pydantic", specifier = ">=2.7,<3.0" },
     { name = "python-multipart", specifier = ">=0.0.9,<1.0" },
     { name = "uvicorn", specifier = ">=0.30,<1.0" },
@@ -331,7 +332,6 @@ requires-dist = [
 
 [package.metadata.requires-dev]
 dev = [
-    { name = "httpx", specifier = ">=0.27,<1.0" },
     { name = "mypy", specifier = ">=1.19" },
     { name = "pytest", specifier = ">=9" },
     { name = "pytest-cov", specifier = ">=7" },


### PR DESCRIPTION
## 背景
高并发（`max_concurrency`）+ 大量 chunk 的场景下，现有 `urllib` 实现缺少连接复用/连接池，容易产生额外握手开销与连接抖动。

## 变更
- `novel_proofer/llm/client.py`：改用 `httpx.Client` 发送请求，并启用连接池（`max_connections/max_keepalive_connections` 与 `max_concurrency` 对齐）。
- loopback/localhost：使用 `trust_env=False` 绕过环境代理（保持旧语义）。
- 依赖：将 `httpx` 作为运行时依赖，并更新 `uv.lock` / `requirements.lock.txt`。
- 测试与文档：更新 `tests/llm/test_client.py`、`docs/TESTCASES.md`、`docs/ARCHITECTURE.md`。

## 验证
- `uv run -m pytest -q`

Closes #13


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **文档更新**
  * 更新了架构文档中关于HTTP客户端连接池的说明。
  * 更新了测试用例文档以反映最新的代理绕过和错误处理机制。

* **依赖更新**
  * httpx 现已作为主要依赖项（v0.27+）。

* **改进**
  * 增强了HTTP连接管理和并发处理能力，提升了系统的稳定性和性能。

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->