### PR TITLE
refactor(api): validate and normalize job_id

### DIFF
--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -52,10 +52,10 @@ novel_proofer/
 │   ├── rules.py       # 确定性文本转换（标点、缩进）
 │   ├── chunking.py    # 按行边界分片（支持文件流式）
 │   └── merge.py       # 分片合并（runner/fixer 复用）
-	└── llm/
-	    ├── config.py      # LLMConfig、系统提示词
-	    ├── client.py      # OpenAI 兼容流式客户端（httpx 连接池）+ 重试逻辑
-	    └── think_filter.py # 状态机过滤 <think> 标签
+└── llm/
+    ├── config.py      # LLMConfig、系统提示词
+    ├── client.py      # OpenAI 兼容流式客户端（httpx 连接池）+ 重试逻辑
+    └── think_filter.py # 状态机过滤 <think> 标签
 ```
 
 | 模块 | 职责 | 关键方法 |

--- a/docs/TESTCASES.md
+++ b/docs/TESTCASES.md
@@ -14,6 +14,8 @@
 | `tests/api/test_endpoints.py::test_create_job_local_mode_writes_output_and_is_queryable` | 提供 LLM 配置创建任务，轮询等待完成；验证输出文件在 `OUTPUT_DIR` 下生成且内容非空，同时清理 `GLOBAL_JOBS` 记录避免串扰。 |
 | `tests/api/test_endpoints.py::test_get_job_chunk_filter_and_paging` | 创建多分片任务后，用 `chunks=1&chunk_state=done&limit=1&offset=0` 拉取分片列表；验证分页 `has_more`、返回数量与 `chunk_counts.done` 统计。 |
 | `tests/api/test_endpoints.py::test_job_not_found_error_envelope` | 查询不存在的任务时返回 `404`，并使用统一错误信封（`error.code == "not_found"`）。 |
+| `tests/api/test_endpoints.py::test_invalid_job_id_returns_400_bad_request` | 非法 `job_id`（非 32 位 hex）应返回 `400`，并使用统一错误信封（`error.code == "bad_request"`）。 |
+| `tests/api/test_endpoints.py::test_job_id_is_normalized_to_lowercase_for_lookup` | `job_id` 大小写不敏感：服务端应在路由层将 path 参数标准化为小写后再查询任务。 |
 | `tests/api/test_endpoints.py::test_create_job_llm_enabled_requires_base_url_and_model` | LLM 配置缺失（`base_url/model` 为空）时，创建任务仍返回 `201`，但任务最终进入 `error` 状态。 |
 | `tests/api/test_endpoints.py::test_job_actions_pause_resume` | 覆盖任务动作接口：`pause/resume` 的返回值与状态流转（通过 monkeypatch 避免真实 runner 副作用）。 |
 | `tests/api/test_endpoints.py::test_pause_only_allowed_in_process_phase` | `pause` 仅允许在 `phase=process` 时执行；其他阶段返回 `409`。 |


### PR DESCRIPTION
## 背景
`api.py` 内部对 `job_id` 的清洗与正则校验存在多处重复实现，并且 path 参数大小写会导致 `GLOBAL_JOBS.get()` 查询不一致（例如客户端传入大写 32 位 hex）。

## 变更
- 新增 `_validate_job_id()`：`strip + lower + 32位hex` 校验，返回标准化后的 job_id。
- 新增 `_job_id_dep()` 并用于所有带 `{job_id}` 的 endpoints：
  - 非法 `job_id` 统一返回 `400`（`bad_request` 错误信封）。
  - 合法但大小写不同的 `job_id` 会被标准化为小写后再查询。
- 将 `_input_cache_path/_input_upload_tmp_path/_cleanup_*` 等内部 helper 复用 `_validate_job_id()`，去重校验逻辑。
- 补充测试：
  - `test_invalid_job_id_returns_400_bad_request`
  - `test_job_id_is_normalized_to_lowercase_for_lookup`
- 更新 `docs/TESTCASES.md`。

## 验证
- `uv run -m pytest -q`
- `uv run ruff check .`
- `uv run ruff format --check .`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 发布说明

* **改进优化**
  * 增强了任务ID验证，无效ID现返回HTTP 400错误
  * 任务ID查询现支持大小写不敏感的标准化处理

* **文档**
  * 调整了架构文档的格式结构

* **测试**
  * 新增ID验证和查询标准化的测试用例

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->