### PR TITLE
refactor: introduce StrEnum for job/chunk states and phases (#34)

### DIFF
--- a/novel_proofer/states.py
+++ b/novel_proofer/states.py
@@ -1,0 +1,27 @@
+from __future__ import annotations
+
+from enum import StrEnum
+
+
+class JobState(StrEnum):
+    QUEUED = "queued"
+    RUNNING = "running"
+    PAUSED = "paused"
+    DONE = "done"
+    ERROR = "error"
+    CANCELLED = "cancelled"
+
+
+class ChunkState(StrEnum):
+    PENDING = "pending"
+    PROCESSING = "processing"
+    RETRYING = "retrying"
+    DONE = "done"
+    ERROR = "error"
+
+
+class JobPhase(StrEnum):
+    VALIDATE = "validate"
+    PROCESS = "process"
+    MERGE = "merge"
+    DONE = "done"


### PR DESCRIPTION
## Summary

Closes #34

新增 \`novel_proofer/states.py\`，定义三个 \`StrEnum\`：
- **\`JobState\`**: queued / running / paused / done / error / cancelled
- **\`ChunkState\`**: pending / processing / retrying / done / error
- **\`JobPhase\`**: validate / process / merge / done

替换 \`jobs.py\`、\`runner.py\`、\`api.py\` 中 ~100 处裸字符串为枚举成员。

\`StrEnum\` 是 \`str\` 子类，JSON 序列化 / Pydantic / 前端完全兼容，测试无需修改即全部通过（123 pass）。

Co-Authored-By: Warp <agent@warp.dev>