### PR TITLE
refactor: replace hand-written serde with dataclasses.asdict (#37)

### DIFF
--- a/novel_proofer/jobs.py
+++ b/novel_proofer/jobs.py
@@ -114,9 +114,9 @@ def _format_config_from_dict(raw: object) -> FormatConfig:
             default = getattr(_FORMAT_DEFAULTS, f.name)
             val = raw.get(f.name, default)
             if isinstance(default, int) and not isinstance(default, bool):
-                kwargs[f.name] = int(val or default)
+                kwargs[f.name] = int(val) if val not in (None, "") else default
             elif isinstance(default, bool):
-                kwargs[f.name] = bool(val) if val is not None else default
+                kwargs[f.name] = val if isinstance(val, bool) else default
             else:
                 kwargs[f.name] = val
         return FormatConfig(**kwargs)


### PR DESCRIPTION
## Summary

Closes #37

### 变更
- \`_chunk_to_dict\` / \`_job_to_dict\` → \`dataclasses.asdict()\`，消除 ~45 行硬编码字段映射
- 新增 \`_format_config_from_dict()\`，使用 \`dataclasses.fields()\` 迭代替代 10 行手工解析
- 新增字段到 \`ChunkStatus\` / \`JobStatus\` / \`FormatConfig\` 现在自动包含在序列化/反序列化中
- 保留 \`_chunk_from_dict\` / \`_job_from_dict\` 的防御逻辑（版本迁移 + 容错）

净减 43 行，123 tests pass。

Co-Authored-By: Warp <agent@warp.dev>