### PR TITLE
[Feature] perf: optimize JobStore polling snapshot overhead

### DIFF
--- a/novel_proofer/jobs.py
+++ b/novel_proofer/jobs.py
@@ -441,9 +441,11 @@ class JobStore:
             st.finished_at = None
 
         # Any in-flight chunks are no longer running; convert them back to pending.
-        for i, cs in enumerate(st.chunk_statuses):
-            if cs.state in {ChunkState.PROCESSING, ChunkState.RETRYING}:
-                st.chunk_statuses[i] = replace(cs, state=ChunkState.PENDING, started_at=None, finished_at=None)
+        _in_flight = {ChunkState.PROCESSING, ChunkState.RETRYING}
+        st.chunk_statuses = [
+            replace(cs, state=ChunkState.PENDING, started_at=None, finished_at=None) if cs.state in _in_flight else cs
+            for cs in st.chunk_statuses
+        ]
 
         # Keep counters consistent even if older files were incomplete.
         st.total_chunks = max(int(st.total_chunks), len(st.chunk_statuses))


### PR DESCRIPTION
Part of #51 | Closes #53

## Problem
Every `GET /api/v1/jobs/{job_id}` poll calls `_snapshot_job()` → `_snapshot_chunk()` for each chunk. With 1000 chunks this means ~1000 dataclass instantiations per request, all producing identical copies of immutable data.

## Solution
Make `ChunkStatus` a frozen dataclass (`@dataclass(frozen=True)`). Frozen instances are immutable and safe to share across snapshot boundaries — no deep copy needed.

### Changes
- `_snapshot_chunk` method removed entirely (frozen = identity safe)
- `_snapshot_job`: `list(st.chunk_statuses)` shallow copy replaces per-element deep copy
- `get_chunks_page`: returns chunk references directly
- 4 mutation sites converted to `dataclasses.replace()`: `update_chunk`, `add_retry`, `cancel`, `_heal_loaded_job`

### Trade-off
Mutation sites now allocate a new `ChunkStatus` per update (via `replace()`). This is acceptable because mutations are infrequent (once per LLM call per chunk) while polls are frequent (every ~1s from UI).

## Test
129/129 tests pass, ruff + mypy clean.

Co-Authored-By: Warp <agent@warp.dev>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 发布说明

* **重构**
  * 改进了内部数据处理机制，通过增强数据结构的不可变性设计，提升了系统稳定性，确保数据在各类操作中保持一致性。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->