### PR TITLE
refactor(workflow): centralize job state guards

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -19,7 +19,8 @@ uv sync --frozen --no-install-project --group dev
 uv run --frozen --no-sync -m novel_proofer.server          # http://127.0.0.1:18080
 
 # tests
-uv run --frozen --no-sync pytest -q
+uv run --frozen --no-sync python -m pytest -q
+uv run --frozen --no-sync python -m mypy novel_proofer
 
 # Windows 自检
 start.bat --smoke

--- a/docs/DEVELOP.md
+++ b/docs/DEVELOP.md
@@ -68,7 +68,7 @@ npm run watch:css
 1. 从 `main` 拉取最新：`git fetch origin`
 2. 新功能/修复从 `main` 开分支（示例）：`feat/ui-drop-upload`、`fix/llm-timeout`
 3. 保持分支小步提交，提交信息遵循 Conventional Commits（见下）
-4. 提交 PR 前自测（至少跑一次 `uv run --frozen --no-sync pytest -q`）
+4. 提交 PR 前自测（至少跑一次 `uv run --frozen --no-sync python -m pytest -q`）
 5. 合并前尽量保持线性历史（按团队偏好：rebase 或 merge commit；禁止 squash merge）
 
 注：如果需要重写已推送历史（如 reword/rebase），请优先使用 `--force-with-lease`，并确保相关分支无人依赖。
@@ -137,7 +137,7 @@ bash tools/setup-git.sh
 推荐直接使用 uv：
 
 ```bash
-uv run --frozen --no-sync pytest -q
+uv run --frozen --no-sync python -m pytest -q
 ```
 
 也可一键跑 smoke：

--- a/docs/PERFORMANCE.md
+++ b/docs/PERFORMANCE.md
@@ -80,5 +80,5 @@ UI 1s 轮询
 
 已执行：
 
-- `uv run --frozen --no-sync pytest -q`
+- `uv run --frozen --no-sync python -m pytest -q`
 - 结果：`124 passed`

--- a/docs/STATE_MACHINE.md
+++ b/docs/STATE_MACHINE.md
@@ -7,6 +7,8 @@
 - **Chunk 状态**：任务内每个分片的生命周期（`pending|processing|retrying|done|error`）。
 
 > 设计原则：`retrying` **不是**“待重试队列”，而是**同一次分片处理内部**的“自动重试/退避等待”中间态；手动“重试失败分片”应当把分片重置为 `pending` 再重新调度。
+>
+> 当前代码把 workflow 决策集中在 `novel_proofer.workflow`：API、runner 与持久化加载都应复用同一组 guard / invariant helper，而不是在各层重复手写状态判断。
 
 ## Chunk 状态机
 
@@ -93,6 +95,13 @@ stateDiagram-v2
 - `progress.total_chunks` / `progress.done_chunks`：进度与百分比展示的基准。
 - `last_retry_count`：全任务范围的自动重试总次数（统计/观测用）。
 - `last_llm_model`（API 里暴露为 `job.llm_model`）：**本轮/最近一次**执行所用模型名（配合每个分片的 `llm_model` 进行定位）。
+
+## 代码边界
+
+- `novel_proofer.workflow`：集中表达状态转移守卫与持久化 invariant，例如 `can_pause()`、`can_resume()`、`can_retry_failed()`、`can_merge()`、`processing_final_state()`、`validate_job_phase_invariants()`。
+- `novel_proofer.api`：只负责把 guard 结果转换成 HTTP 响应与提交后台任务，不再拥有独立的 workflow 判断规则。
+- `novel_proofer.runner`：只负责执行阶段，并在阶段结束时调用 workflow helper 判定最终进入 `error` 还是 `merge`。
+- `novel_proofer.jobs`：只负责存储/持久化/恢复，并复用 workflow invariant 校验落盘状态是否自洽。
 
 ## UI 展示约定（推荐）
 

--- a/docs/TESTCASES.md
+++ b/docs/TESTCASES.md
@@ -1,8 +1,8 @@
 # 测试用例说明
 
-在仓库根目录执行 `uv run --frozen --no-sync pytest --collect-only -q`，pytest 会收集到若干测试用例（包含参数化展开；具体数量以本地输出为准）。本文档按文件列出每个用例的覆盖点，便于快速定位“在测什么”。
+在仓库根目录执行 `uv run --frozen --no-sync python -m pytest --collect-only -q`，pytest 会收集到若干测试用例（包含参数化展开；具体数量以本地输出为准）。本文档按文件列出每个用例的覆盖点，便于快速定位“在测什么”。
 
-如需运行全部测试：`uv run --frozen --no-sync pytest -q`。
+如需运行全部测试：`uv run --frozen --no-sync python -m pytest -q`。
 
 注意：若设置 `NOVEL_PROOFER_RUN_LLM_TESTS=true`（或传入 `--run-llm-tests`），会额外运行标记为 `llm_integration` 的真实 LLM 集成测试。
 

--- a/novel_proofer/api.py
+++ b/novel_proofer/api.py
@@ -57,6 +57,7 @@ from novel_proofer.models import (
 )
 from novel_proofer.runner import merge_outputs, resume_paused_job, retry_failed_chunks, run_job
 from novel_proofer.states import ChunkState, JobPhase, JobState
+from novel_proofer.workflow import ResumeTarget, can_merge, can_pause, can_resume, can_retry_failed
 
 logger = logging.getLogger(__name__)
 
@@ -525,11 +526,11 @@ async def pause_job(job_id: str = Depends(paths._job_id_dep)):
     st = GLOBAL_JOBS.get(job_id)
     if st is None:
         raise HTTPException(status_code=404, detail="job not found")
-    phase = st.phase.strip().lower()
-    if phase != JobPhase.PROCESS:
-        raise HTTPException(status_code=409, detail=f"cannot pause job in phase={phase or None}")
+    pause_guard = can_pause(st.state, st.phase)
+    if not pause_guard.allowed:
+        raise HTTPException(status_code=409, detail=pause_guard.reason)
     if not GLOBAL_JOBS.pause(job_id):
-        raise HTTPException(status_code=409, detail=f"cannot pause job in state={st.state}")
+        raise HTTPException(status_code=409, detail="failed to pause job")
     st2 = GLOBAL_JOBS.get(job_id) or st
     return JobActionResponse(ok=True, job=_job_to_out(st2))
 
@@ -541,26 +542,18 @@ async def resume_job(
     st = GLOBAL_JOBS.get(job_id)
     if st is None:
         raise HTTPException(status_code=404, detail="job not found")
-    if st.state == JobState.RUNNING:
-        raise HTTPException(status_code=409, detail="job is running")
-    if st.state == JobState.CANCELLED:
-        raise HTTPException(status_code=409, detail="job is cancelled")
-    if st.state != JobState.PAUSED:
-        raise HTTPException(status_code=409, detail="job is not paused")
-    if st.phase == JobPhase.MERGE:
-        raise HTTPException(status_code=409, detail="job is ready to merge")
-    if st.phase == JobPhase.DONE:
-        raise HTTPException(status_code=409, detail="job is already done")
+    resume_guard = can_resume(st.state, st.phase)
+    if not resume_guard.allowed:
+        raise HTTPException(status_code=409, detail=resume_guard.reason)
     if not GLOBAL_JOBS.resume(job_id):
         raise HTTPException(status_code=409, detail="failed to resume job")
 
     llm = _llm_from_options(body.llm or LLMOptions())
     prev_llm_model = st.last_llm_model
     GLOBAL_JOBS.update(job_id, last_llm_model=llm.model)
-    phase = st.phase
     fn: Callable[..., Any]
     args: tuple[Any, ...]
-    if phase == JobPhase.VALIDATE:
+    if resume_guard.target == ResumeTarget.VALIDATE:
         fmt = st.format
         fn = run_job
         args = (job_id, paths._input_cache_path(job_id), fmt, llm)
@@ -589,18 +582,11 @@ async def retry_failed(
     st = GLOBAL_JOBS.get(job_id)
     if st is None:
         raise HTTPException(status_code=404, detail="job not found")
-    if GLOBAL_JOBS.is_cancelled(job_id):
-        raise HTTPException(status_code=409, detail="job is cancelled")
-    if st.state == JobState.RUNNING:
-        raise HTTPException(status_code=409, detail="job is running")
-    if st.state == JobState.CANCELLED:
-        raise HTTPException(status_code=409, detail="job is cancelled")
-    if st.state != JobState.ERROR:
-        raise HTTPException(status_code=409, detail=f"job is not in error state (state={st.state})")
+    retry_guard = can_retry_failed(st.state, [c.state for c in st.chunk_statuses])
+    if not retry_guard.allowed:
+        raise HTTPException(status_code=409, detail=retry_guard.reason)
 
     failed = [c.index for c in st.chunk_statuses if c.state == ChunkState.ERROR]
-    if not failed:
-        raise HTTPException(status_code=409, detail="no failed chunks to retry")
 
     llm = _llm_from_options(body.llm or LLMOptions())
     prev_llm_model = st.last_llm_model
@@ -641,16 +627,9 @@ async def merge_job(job_id: str = Depends(paths._job_id_dep), body: MergeRequest
     st = GLOBAL_JOBS.get(job_id)
     if st is None:
         raise HTTPException(status_code=404, detail="job not found")
-    if GLOBAL_JOBS.is_cancelled(job_id) or st.state == JobState.CANCELLED:
-        raise HTTPException(status_code=409, detail="job is cancelled")
-    if st.state == JobState.RUNNING:
-        raise HTTPException(status_code=409, detail="job is running")
-    if st.state != JobState.PAUSED:
-        raise HTTPException(status_code=409, detail=f"job is not paused (state={st.state})")
-    if st.phase != JobPhase.MERGE:
-        raise HTTPException(status_code=409, detail=f"job is not ready to merge (phase={st.phase})")
-    if not st.chunk_statuses or any(c.state != ChunkState.DONE for c in st.chunk_statuses):
-        raise HTTPException(status_code=409, detail="job is not ready to merge (chunks incomplete)")
+    merge_guard = can_merge(st.state, st.phase, [c.state for c in st.chunk_statuses])
+    if not merge_guard.allowed:
+        raise HTTPException(status_code=409, detail=merge_guard.reason)
 
     if not GLOBAL_JOBS.resume(job_id):
         raise HTTPException(status_code=409, detail="failed to start merge")

--- a/novel_proofer/jobs.py
+++ b/novel_proofer/jobs.py
@@ -15,6 +15,7 @@ from typing import Any
 from novel_proofer.env import env_float
 from novel_proofer.formatting.config import FormatConfig
 from novel_proofer.states import ChunkState, JobPhase, JobState
+from novel_proofer.workflow import WorkflowInvariantError, validate_job_phase_invariants
 
 logger = logging.getLogger(__name__)
 
@@ -359,14 +360,10 @@ def _job_from_dict(d: dict) -> JobStatus:
 
     state = _parse_enum(_require_field(job, "state", context="job"), context="job.state", allowed=_JOB_STATES)
     phase = _parse_enum(_require_field(job, "phase", context="job"), context="job.phase", allowed=_JOB_PHASES)
-    if state == JobState.DONE and phase != JobPhase.DONE:
-        raise ValueError("job.phase must be 'done' when job.state is 'done'")
-    if phase == JobPhase.DONE and state != JobState.DONE:
-        raise ValueError("job.state must be 'done' when job.phase is 'done'")
-    if phase == JobPhase.MERGE and any(chunk.state != ChunkState.DONE for chunk in chunks):
-        raise ValueError("job.phase 'merge' requires every chunk to be done")
-    if state == JobState.DONE and any(chunk.state != ChunkState.DONE for chunk in chunks):
-        raise ValueError("job.state 'done' requires every chunk to be done")
+    try:
+        validate_job_phase_invariants(state, phase, [chunk.state for chunk in chunks])
+    except WorkflowInvariantError as e:
+        raise ValueError(str(e)) from e
 
     job_id = _parse_str(_require_field(job, "job_id", context="job"), context="job.job_id", allow_empty=False)
     if not _JOB_ID_RE.fullmatch(job_id):

--- a/novel_proofer/runner.py
+++ b/novel_proofer/runner.py
@@ -19,6 +19,7 @@ from novel_proofer.jobs import GLOBAL_JOBS
 from novel_proofer.llm.client import LLMError, call_llm_text_resilient_with_meta_and_raw
 from novel_proofer.llm.config import LLMConfig, build_first_chunk_config
 from novel_proofer.states import ChunkState, JobPhase, JobState
+from novel_proofer.workflow import ProcessingFinalState, processing_final_state
 
 logger = logging.getLogger(__name__)
 
@@ -234,8 +235,8 @@ def _finalize_processing(job_id: str, total: int, error_msg: str) -> bool:
     if cur is None:
         return False
 
-    has_error = any(c.state == ChunkState.ERROR for c in cur.chunk_statuses)
-    if has_error:
+    final_state = processing_final_state([c.state for c in cur.chunk_statuses])
+    if final_state == ProcessingFinalState.ERROR:
         GLOBAL_JOBS.update(
             job_id,
             state=JobState.ERROR,

--- a/novel_proofer/workflow.py
+++ b/novel_proofer/workflow.py
@@ -1,0 +1,149 @@
+from __future__ import annotations
+
+from collections.abc import Iterable
+from dataclasses import dataclass
+from enum import StrEnum
+
+from novel_proofer.states import ChunkState, JobPhase, JobState
+
+
+class WorkflowInvariantError(ValueError):
+    pass
+
+
+class ResumeTarget(StrEnum):
+    VALIDATE = "validate"
+    PROCESS = "process"
+
+
+class ProcessingFinalState(StrEnum):
+    ERROR = "error"
+    READY_TO_MERGE = "ready_to_merge"
+
+
+@dataclass(frozen=True)
+class WorkflowGuard:
+    allowed: bool
+    reason: str | None = None
+
+    @classmethod
+    def allow(cls) -> WorkflowGuard:
+        return cls(True)
+
+    @classmethod
+    def reject(cls, reason: str) -> WorkflowGuard:
+        return cls(False, reason)
+
+
+@dataclass(frozen=True)
+class ResumeGuard(WorkflowGuard):
+    target: ResumeTarget | None = None
+
+    @classmethod
+    def allow_target(cls, target: ResumeTarget) -> ResumeGuard:
+        return cls(True, target=target)
+
+    @classmethod
+    def reject(cls, reason: str) -> ResumeGuard:
+        return cls(False, reason=reason)
+
+
+def _state_value(state: JobState | str) -> str:
+    return JobState(state).value
+
+
+def _phase_value(phase: JobPhase | str) -> str:
+    return JobPhase(phase).value
+
+
+def _chunk_states(chunks: Iterable[ChunkState | str]) -> list[ChunkState]:
+    return [ChunkState(chunk) for chunk in chunks]
+
+
+def is_in_flight_job_state(state: JobState | str) -> bool:
+    return JobState(state) in {JobState.QUEUED, JobState.RUNNING}
+
+
+def can_pause(state: JobState | str, phase: JobPhase | str) -> WorkflowGuard:
+    state_value = _state_value(state)
+    phase_value = _phase_value(phase)
+    if phase_value != JobPhase.PROCESS:
+        return WorkflowGuard.reject(f"cannot pause job in phase={phase_value}")
+    if not is_in_flight_job_state(state_value):
+        return WorkflowGuard.reject(f"cannot pause job in state={state_value}")
+    return WorkflowGuard.allow()
+
+
+def can_resume(state: JobState | str, phase: JobPhase | str) -> ResumeGuard:
+    state_value = _state_value(state)
+    phase_value = _phase_value(phase)
+    if state_value == JobState.RUNNING:
+        return ResumeGuard.reject("job is running")
+    if state_value == JobState.CANCELLED:
+        return ResumeGuard.reject("job is cancelled")
+    if state_value != JobState.PAUSED:
+        return ResumeGuard.reject("job is not paused")
+    if phase_value == JobPhase.MERGE:
+        return ResumeGuard.reject("job is ready to merge")
+    if phase_value == JobPhase.DONE:
+        return ResumeGuard.reject("job is already done")
+    if phase_value == JobPhase.VALIDATE:
+        return ResumeGuard.allow_target(ResumeTarget.VALIDATE)
+    if phase_value == JobPhase.PROCESS:
+        return ResumeGuard.allow_target(ResumeTarget.PROCESS)
+    return ResumeGuard.reject(f"cannot resume job in phase={phase_value}")
+
+
+def can_retry_failed(state: JobState | str, chunks: Iterable[ChunkState | str]) -> WorkflowGuard:
+    state_value = _state_value(state)
+    if state_value == JobState.CANCELLED:
+        return WorkflowGuard.reject("job is cancelled")
+    if state_value == JobState.RUNNING:
+        return WorkflowGuard.reject("job is running")
+    if state_value != JobState.ERROR:
+        return WorkflowGuard.reject(f"job is not in error state (state={state_value})")
+    if not any(chunk == ChunkState.ERROR for chunk in _chunk_states(chunks)):
+        return WorkflowGuard.reject("no failed chunks to retry")
+    return WorkflowGuard.allow()
+
+
+def can_merge(state: JobState | str, phase: JobPhase | str, chunks: Iterable[ChunkState | str]) -> WorkflowGuard:
+    state_value = _state_value(state)
+    phase_value = _phase_value(phase)
+    chunk_states = _chunk_states(chunks)
+    if state_value == JobState.CANCELLED:
+        return WorkflowGuard.reject("job is cancelled")
+    if state_value == JobState.RUNNING:
+        return WorkflowGuard.reject("job is running")
+    if state_value != JobState.PAUSED:
+        return WorkflowGuard.reject(f"job is not paused (state={state_value})")
+    if phase_value != JobPhase.MERGE:
+        return WorkflowGuard.reject(f"job is not ready to merge (phase={phase_value})")
+    if not chunk_states or any(chunk != ChunkState.DONE for chunk in chunk_states):
+        return WorkflowGuard.reject("job is not ready to merge (chunks incomplete)")
+    return WorkflowGuard.allow()
+
+
+def processing_final_state(chunks: Iterable[ChunkState | str]) -> ProcessingFinalState:
+    chunk_states = _chunk_states(chunks)
+    if any(chunk == ChunkState.ERROR for chunk in chunk_states):
+        return ProcessingFinalState.ERROR
+    return ProcessingFinalState.READY_TO_MERGE
+
+
+def validate_job_phase_invariants(
+    state: JobState | str,
+    phase: JobPhase | str,
+    chunks: Iterable[ChunkState | str],
+) -> None:
+    state_value = JobState(state)
+    phase_value = JobPhase(phase)
+    chunk_states = _chunk_states(chunks)
+    if state_value == JobState.DONE and phase_value != JobPhase.DONE:
+        raise WorkflowInvariantError("job.phase must be 'done' when job.state is 'done'")
+    if phase_value == JobPhase.DONE and state_value != JobState.DONE:
+        raise WorkflowInvariantError("job.state must be 'done' when job.phase is 'done'")
+    if phase_value == JobPhase.MERGE and any(chunk != ChunkState.DONE for chunk in chunk_states):
+        raise WorkflowInvariantError("job.phase 'merge' requires every chunk to be done")
+    if state_value == JobState.DONE and any(chunk != ChunkState.DONE for chunk in chunk_states):
+        raise WorkflowInvariantError("job.state 'done' requires every chunk to be done")

--- a/novel_proofer/workflow.py
+++ b/novel_proofer/workflow.py
@@ -48,12 +48,12 @@ class ResumeGuard(WorkflowGuard):
         return cls(False, reason=reason)
 
 
-def _state_value(state: JobState | str) -> str:
-    return JobState(state).value
+def _as_state(state: JobState | str) -> JobState:
+    return JobState(state)
 
 
-def _phase_value(phase: JobPhase | str) -> str:
-    return JobPhase(phase).value
+def _as_phase(phase: JobPhase | str) -> JobPhase:
+    return JobPhase(phase)
 
 
 def _chunk_states(chunks: Iterable[ChunkState | str]) -> list[ChunkState]:
@@ -65,60 +65,60 @@ def is_in_flight_job_state(state: JobState | str) -> bool:
 
 
 def can_pause(state: JobState | str, phase: JobPhase | str) -> WorkflowGuard:
-    state_value = _state_value(state)
-    phase_value = _phase_value(phase)
-    if phase_value != JobPhase.PROCESS:
-        return WorkflowGuard.reject(f"cannot pause job in phase={phase_value}")
-    if not is_in_flight_job_state(state_value):
-        return WorkflowGuard.reject(f"cannot pause job in state={state_value}")
+    st = _as_state(state)
+    ph = _as_phase(phase)
+    if ph != JobPhase.PROCESS:
+        return WorkflowGuard.reject(f"cannot pause job in phase={ph.value}")
+    if st not in {JobState.QUEUED, JobState.RUNNING}:
+        return WorkflowGuard.reject(f"cannot pause job in state={st.value}")
     return WorkflowGuard.allow()
 
 
 def can_resume(state: JobState | str, phase: JobPhase | str) -> ResumeGuard:
-    state_value = _state_value(state)
-    phase_value = _phase_value(phase)
-    if state_value == JobState.RUNNING:
+    st = _as_state(state)
+    ph = _as_phase(phase)
+    if st == JobState.RUNNING:
         return ResumeGuard.reject("job is running")
-    if state_value == JobState.CANCELLED:
+    if st == JobState.CANCELLED:
         return ResumeGuard.reject("job is cancelled")
-    if state_value != JobState.PAUSED:
+    if st != JobState.PAUSED:
         return ResumeGuard.reject("job is not paused")
-    if phase_value == JobPhase.MERGE:
+    if ph == JobPhase.MERGE:
         return ResumeGuard.reject("job is ready to merge")
-    if phase_value == JobPhase.DONE:
+    if ph == JobPhase.DONE:
         return ResumeGuard.reject("job is already done")
-    if phase_value == JobPhase.VALIDATE:
+    if ph == JobPhase.VALIDATE:
         return ResumeGuard.allow_target(ResumeTarget.VALIDATE)
-    if phase_value == JobPhase.PROCESS:
+    if ph == JobPhase.PROCESS:
         return ResumeGuard.allow_target(ResumeTarget.PROCESS)
-    return ResumeGuard.reject(f"cannot resume job in phase={phase_value}")
+    return ResumeGuard.reject(f"cannot resume job in phase={ph.value}")
 
 
 def can_retry_failed(state: JobState | str, chunks: Iterable[ChunkState | str]) -> WorkflowGuard:
-    state_value = _state_value(state)
-    if state_value == JobState.CANCELLED:
+    st = _as_state(state)
+    if st == JobState.CANCELLED:
         return WorkflowGuard.reject("job is cancelled")
-    if state_value == JobState.RUNNING:
+    if st == JobState.RUNNING:
         return WorkflowGuard.reject("job is running")
-    if state_value != JobState.ERROR:
-        return WorkflowGuard.reject(f"job is not in error state (state={state_value})")
+    if st != JobState.ERROR:
+        return WorkflowGuard.reject(f"job is not in error state (state={st.value})")
     if not any(chunk == ChunkState.ERROR for chunk in _chunk_states(chunks)):
         return WorkflowGuard.reject("no failed chunks to retry")
     return WorkflowGuard.allow()
 
 
 def can_merge(state: JobState | str, phase: JobPhase | str, chunks: Iterable[ChunkState | str]) -> WorkflowGuard:
-    state_value = _state_value(state)
-    phase_value = _phase_value(phase)
+    st = _as_state(state)
+    ph = _as_phase(phase)
     chunk_states = _chunk_states(chunks)
-    if state_value == JobState.CANCELLED:
+    if st == JobState.CANCELLED:
         return WorkflowGuard.reject("job is cancelled")
-    if state_value == JobState.RUNNING:
+    if st == JobState.RUNNING:
         return WorkflowGuard.reject("job is running")
-    if state_value != JobState.PAUSED:
-        return WorkflowGuard.reject(f"job is not paused (state={state_value})")
-    if phase_value != JobPhase.MERGE:
-        return WorkflowGuard.reject(f"job is not ready to merge (phase={phase_value})")
+    if st != JobState.PAUSED:
+        return WorkflowGuard.reject(f"job is not paused (state={st.value})")
+    if ph != JobPhase.MERGE:
+        return WorkflowGuard.reject(f"job is not ready to merge (phase={ph.value})")
     if not chunk_states or any(chunk != ChunkState.DONE for chunk in chunk_states):
         return WorkflowGuard.reject("job is not ready to merge (chunks incomplete)")
     return WorkflowGuard.allow()

--- a/templates/static/js/ui.js
+++ b/templates/static/js/ui.js
@@ -1,5 +1,6 @@
 
 import { state, UI_STATE_FIELDS } from './state.js';
+import { actionAvailability, primaryActionKey } from './workflow.js';
 
 // DOM Elements Cache
 export const elements = {};
@@ -504,9 +505,11 @@ function _setDisabled(el, disabled) {
 }
 
 export function refreshActionButtons(job) {
-    const st = String(job?.state || '').toLowerCase();
-    const phase = String(job?.phase || '').toLowerCase();
-    const hasJob = !!job;
+    const hasLocalFile = !!elements.fileInput?.files?.[0];
+    const actions = actionAvailability(job, {
+        hasLocalFile,
+        createJobInFlight: state.createJobInFlight,
+    });
 
     // Styles
     const BTN_SOLID_INK = 'w-full px-5 py-2.5 bg-ink hover:bg-zinc-800 text-white text-sm font-medium rounded-lg transition-colors active:scale-[0.99]';
@@ -517,37 +520,25 @@ export function refreshActionButtons(job) {
     const BTN_OUTLINE_AMBER = 'w-full px-5 py-2.5 bg-white border border-amber-200 text-amber-700 hover:bg-amber-50 text-sm font-medium rounded-lg transition-colors';
     const BTN_OUTLINE_RED = 'w-full px-5 py-2.5 bg-white border border-red-200 text-red-700 hover:bg-red-50 text-sm font-medium rounded-lg transition-colors';
 
-    const canResumeValidate = hasJob && st === 'paused' && phase === 'validate';
-    const hasLocalFile = !!elements.fileInput?.files?.[0];
-    const canStartValidate = (!hasJob) && hasLocalFile && !state.createJobInFlight;
-    const canValidate = canResumeValidate || canStartValidate;
-    const isSubmitting = (!hasJob) && state.createJobInFlight;
-
-    if (elements.btnValidate) elements.btnValidate.textContent = canResumeValidate ? '继续预处理' : (isSubmitting ? '提交中...' : '开始预处理');
-
-    const canProcess = hasJob && st === 'paused' && phase === 'process';
-    if (elements.btnProcess) {
-        const done = Number(job?.progress?.done_chunks || 0);
-        elements.btnProcess.textContent = (hasJob && phase === 'process' && done > 0) ? '继续校对' : '开始校对';
+    if (elements.btnValidate) {
+        elements.btnValidate.textContent = actions.canResumeValidate
+            ? '继续预处理'
+            : (actions.isSubmitting ? '提交中...' : '开始预处理');
     }
 
-    const canMerge = hasJob && st === 'paused' && phase === 'merge';
-    const canPause = hasJob && (st === 'queued' || st === 'running') && phase === 'process';
-    const canRetry = hasJob && st === 'error';
-    const canNewTask = hasJob && !(st === 'queued' || st === 'running');
-    const canDeleteTask = hasJob && !((st === 'queued' || st === 'running') && phase === 'process');
-    const canDownload = hasJob && st === 'done';
+    if (elements.btnProcess) {
+        elements.btnProcess.textContent = (actions.hasJob && actions.phase === 'process' && actions.doneChunks > 0)
+            ? '继续校对'
+            : '开始校对';
+    }
 
     if (elements.btnCancel) elements.btnCancel.textContent = '新任务';
-    if (elements.btnReset) elements.btnReset.textContent = (hasJob && st === 'done') ? '删除任务记录' : '删除任务';
+    if (elements.btnReset) elements.btnReset.textContent = (actions.hasJob && actions.state === 'done') ? '删除任务记录' : '删除任务';
 
-    let primaryKey = null;
-    if (!hasJob || (st === 'paused' && phase === 'validate')) primaryKey = 'validate';
-    else if (st === 'paused' && phase === 'process') primaryKey = 'process';
-    else if (st === 'paused' && phase === 'merge') primaryKey = 'merge';
-    else if (st === 'done') primaryKey = 'download';
-    else if ((st === 'queued' || st === 'running') && phase === 'process') primaryKey = 'pause';
-    else if (st === 'error') primaryKey = 'retry';
+    const primaryKey = primaryActionKey(job, {
+        hasLocalFile,
+        createJobInFlight: state.createJobInFlight,
+    });
 
     if (elements.btnValidate) elements.btnValidate.className = (primaryKey === 'validate') ? BTN_SOLID_INK : BTN_OUTLINE;
     if (elements.btnProcess) elements.btnProcess.className = (primaryKey === 'process') ? BTN_SOLID_INK : BTN_OUTLINE;
@@ -559,14 +550,14 @@ export function refreshActionButtons(job) {
     if (elements.btnReset) elements.btnReset.className = BTN_OUTLINE_RED;
     if (elements.btnLoad) elements.btnLoad.className = BTN_OUTLINE;
 
-    _setDisabled(elements.btnValidate, !canValidate);
-    _setDisabled(elements.btnProcess, !canProcess);
-    _setDisabled(elements.btnMerge, !canMerge);
-    _setDisabled(elements.btnPause, !canPause);
-    _setDisabled(elements.btnRetry, !canRetry);
-    _setDisabled(elements.btnCancel, !canNewTask);
-    _setDisabled(elements.btnReset, !canDeleteTask);
-    _setDisabled(elements.btnDownload, !canDownload);
+    _setDisabled(elements.btnValidate, !actions.canValidate);
+    _setDisabled(elements.btnProcess, !actions.canProcess);
+    _setDisabled(elements.btnMerge, !actions.canMerge);
+    _setDisabled(elements.btnPause, !actions.canPause);
+    _setDisabled(elements.btnRetry, !actions.canRetry);
+    _setDisabled(elements.btnCancel, !actions.canDetach);
+    _setDisabled(elements.btnReset, !actions.canHardReset);
+    _setDisabled(elements.btnDownload, !actions.canDownload);
     _setDisabled(elements.btnLoad, false);
 
     refreshWorkflowStepper(job);

--- a/templates/static/js/workflow.js
+++ b/templates/static/js/workflow.js
@@ -1,0 +1,48 @@
+// Workflow state helpers shared by UI rendering and event handlers.
+
+export function normalizeJobState(job) {
+    return {
+        hasJob: !!job,
+        state: String(job?.state || '').toLowerCase(),
+        phase: String(job?.phase || '').toLowerCase(),
+        doneChunks: Number(job?.progress?.done_chunks || 0),
+    };
+}
+
+export function isInFlight(stateName) {
+    return stateName === 'queued' || stateName === 'running';
+}
+
+export function actionAvailability(job, { hasLocalFile = false, createJobInFlight = false } = {}) {
+    const view = normalizeJobState(job);
+    const inFlight = isInFlight(view.state);
+    const canResumeValidate = view.hasJob && view.state === 'paused' && view.phase === 'validate';
+    const canStartValidate = !view.hasJob && !!hasLocalFile && !createJobInFlight;
+
+    return {
+        ...view,
+        inFlight,
+        canResumeValidate,
+        canStartValidate,
+        canValidate: canResumeValidate || canStartValidate,
+        isSubmitting: !view.hasJob && !!createJobInFlight,
+        canProcess: view.hasJob && view.state === 'paused' && view.phase === 'process',
+        canMerge: view.hasJob && view.state === 'paused' && view.phase === 'merge',
+        canPause: view.hasJob && inFlight && view.phase === 'process',
+        canRetry: view.hasJob && view.state === 'error',
+        canDetach: view.hasJob && !inFlight,
+        canHardReset: view.hasJob && !(inFlight && view.phase === 'process'),
+        canDownload: view.hasJob && view.state === 'done',
+    };
+}
+
+export function primaryActionKey(job, options = {}) {
+    const availability = actionAvailability(job, options);
+    if (!availability.hasJob || availability.canResumeValidate) return 'validate';
+    if (availability.canProcess) return 'process';
+    if (availability.canMerge) return 'merge';
+    if (availability.canDownload) return 'download';
+    if (availability.canPause) return 'pause';
+    if (availability.canRetry) return 'retry';
+    return null;
+}

--- a/templates/static/js/workflow.js
+++ b/templates/static/js/workflow.js
@@ -2,7 +2,7 @@
 
 export function normalizeJobState(job) {
     return {
-        hasJob: !!job,
+        hasJob: !!job?.id,
         state: String(job?.state || '').toLowerCase(),
         phase: String(job?.phase || '').toLowerCase(),
         doneChunks: Number(job?.progress?.done_chunks || 0),

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -5,7 +5,7 @@ import sys
 from pathlib import Path
 
 # Avoid polluting the host environment: tests assume the repo `.venv` is managed by uv.
-# Use `uv run pytest -q` or `start.bat --smoke`.
+# Use `uv run --frozen --no-sync python -m pytest -q` or `start.bat --smoke`.
 import pytest
 
 # Ensure the repo root (containing `novel_proofer/`) is importable when pytest
@@ -95,7 +95,7 @@ def pytest_configure(config):
     if not in_venv:
         raise RuntimeError(
             "Tests must run inside the repo virtualenv (.venv) managed by uv. "
-            "Use `uv run pytest -q` or `start.bat --smoke`."
+            "Use `uv run --frozen --no-sync python -m pytest -q` or `start.bat --smoke`."
         )
 
 

--- a/tests/test_workflow.py
+++ b/tests/test_workflow.py
@@ -1,0 +1,96 @@
+from __future__ import annotations
+
+import pytest
+
+from novel_proofer.states import ChunkState, JobPhase, JobState
+from novel_proofer.workflow import (
+    ProcessingFinalState,
+    ResumeTarget,
+    WorkflowInvariantError,
+    can_merge,
+    can_pause,
+    can_resume,
+    can_retry_failed,
+    processing_final_state,
+    validate_job_phase_invariants,
+)
+
+
+def test_pause_guard_is_process_only_and_in_flight_only() -> None:
+    assert can_pause(JobState.RUNNING, JobPhase.PROCESS).allowed is True
+    assert can_pause(JobState.QUEUED, JobPhase.PROCESS).allowed is True
+
+    validate_guard = can_pause(JobState.RUNNING, JobPhase.VALIDATE)
+    assert validate_guard.allowed is False
+    assert validate_guard.reason == "cannot pause job in phase=validate"
+
+    paused_guard = can_pause(JobState.PAUSED, JobPhase.PROCESS)
+    assert paused_guard.allowed is False
+    assert paused_guard.reason == "cannot pause job in state=paused"
+
+
+def test_resume_guard_selects_validate_or_process_target() -> None:
+    validate_guard = can_resume(JobState.PAUSED, JobPhase.VALIDATE)
+    assert validate_guard.allowed is True
+    assert validate_guard.target == ResumeTarget.VALIDATE
+
+    process_guard = can_resume(JobState.PAUSED, JobPhase.PROCESS)
+    assert process_guard.allowed is True
+    assert process_guard.target == ResumeTarget.PROCESS
+
+    merge_guard = can_resume(JobState.PAUSED, JobPhase.MERGE)
+    assert merge_guard.allowed is False
+    assert merge_guard.reason == "job is ready to merge"
+
+    running_guard = can_resume(JobState.RUNNING, JobPhase.PROCESS)
+    assert running_guard.allowed is False
+    assert running_guard.reason == "job is running"
+
+
+def test_retry_guard_requires_error_state_with_failed_chunks() -> None:
+    ok = can_retry_failed(JobState.ERROR, [ChunkState.DONE, ChunkState.ERROR])
+    assert ok.allowed is True
+
+    no_failed = can_retry_failed(JobState.ERROR, [ChunkState.DONE])
+    assert no_failed.allowed is False
+    assert no_failed.reason == "no failed chunks to retry"
+
+    paused = can_retry_failed(JobState.PAUSED, [ChunkState.ERROR])
+    assert paused.allowed is False
+    assert paused.reason == "job is not in error state (state=paused)"
+
+
+def test_processing_final_state_depends_only_on_chunk_states() -> None:
+    failed = processing_final_state([ChunkState.DONE, ChunkState.ERROR])
+    assert failed == ProcessingFinalState.ERROR
+
+    ready = processing_final_state([ChunkState.DONE, ChunkState.DONE])
+    assert ready == ProcessingFinalState.READY_TO_MERGE
+
+
+def test_merge_guard_requires_paused_merge_phase_and_complete_chunks() -> None:
+    ok = can_merge(JobState.PAUSED, JobPhase.MERGE, [ChunkState.DONE, ChunkState.DONE])
+    assert ok.allowed is True
+
+    running = can_merge(JobState.RUNNING, JobPhase.MERGE, [ChunkState.DONE])
+    assert running.allowed is False
+    assert running.reason == "job is running"
+
+    wrong_phase = can_merge(JobState.PAUSED, JobPhase.PROCESS, [ChunkState.DONE])
+    assert wrong_phase.allowed is False
+    assert wrong_phase.reason == "job is not ready to merge (phase=process)"
+
+    incomplete = can_merge(JobState.PAUSED, JobPhase.MERGE, [ChunkState.DONE, ChunkState.PENDING])
+    assert incomplete.allowed is False
+    assert incomplete.reason == "job is not ready to merge (chunks incomplete)"
+
+
+def test_persisted_phase_invariants_are_centralized() -> None:
+    validate_job_phase_invariants(JobState.DONE, JobPhase.DONE, [ChunkState.DONE])
+    validate_job_phase_invariants(JobState.PAUSED, JobPhase.MERGE, [ChunkState.DONE])
+
+    with pytest.raises(WorkflowInvariantError, match=r"job\.phase must be 'done'"):
+        validate_job_phase_invariants(JobState.DONE, JobPhase.MERGE, [ChunkState.DONE])
+
+    with pytest.raises(WorkflowInvariantError, match="requires every chunk to be done"):
+        validate_job_phase_invariants(JobState.PAUSED, JobPhase.MERGE, [ChunkState.DONE, ChunkState.ERROR])


### PR DESCRIPTION
## Summary
- centralize job workflow guards and persisted-state invariants in `novel_proofer.workflow`
- reuse workflow guards from API, runner, and JobStore instead of duplicating state/phase checks
- centralize frontend action availability in `templates/static/js/workflow.js`
- update uv verification commands to use `python -m ...`

## Verification
- `NOVEL_PROOFER_RUN_LLM_TESTS= uv run --frozen --no-sync python -m pytest -q` → 139 passed, 5 skipped
- `uv run --frozen --no-sync python -m mypy novel_proofer` → success
- `uv run --frozen --no-sync python -m ruff check .` → all checks passed
- `OPENSPEC_TELEMETRY=0 openspec validate refactor-job-workflow-recovery --strict` → valid
- `npm run build:css` → done

## Notes
- Real LLM integration tests remain intentionally out of scope for this refactor.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 发布说明

* **新增功能**
  * 实现了工作流守卫系统，对暂停、恢复、重试和合并等任务操作进行统一的可用性检查。
  * 前端界面按钮现在根据任务状态动态显示可用的操作。

* **Bug 修复**
  * 改进了任务生命周期操作的验证逻辑，防止无效的状态转换。
  * API 端点现在返回标准化的 409 错误响应，当操作不被允许时。

* **文档**
  * 更新了开发指南中的测试和性能验证命令。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->