### PR TITLE
[Feature] 配置 agent issue 工作流

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -100,6 +100,20 @@ Rules in `formatting/rules.py` (order matters):
 - `POST /api/v1/jobs/purge-all` - Delete all jobs except optionally excluded IDs
 - `GET /api/v1/settings/llm` / `PUT` - Read/write default LLM settings
 
+## Agent skills
+
+### Issue tracker
+
+Issues and PRDs are tracked in GitHub Issues for `makoMakoGo/novel-proofer`. See `docs/agents/issue-tracker.md`.
+
+### Triage labels
+
+The repo uses the canonical engineering-skill triage label vocabulary. See `docs/agents/triage-labels.md`.
+
+### Domain docs
+
+This is a single-context repo; use OpenSpec plus the project docs as the domain source of truth. See `docs/agents/domain.md`.
+
 <!-- OPENSPEC:START -->
 # OpenSpec Instructions
 

--- a/docs/agents/domain.md
+++ b/docs/agents/domain.md
@@ -1,0 +1,24 @@
+# Domain Docs
+
+This is a single-context repo for Novel Proofer, a local Chinese novel formatting/proofreading tool.
+
+## Read First
+
+- `openspec/project.md` for project conventions and domain constraints.
+- Relevant current specs under `openspec/specs/`.
+- Active changes under `openspec/changes/` before proposing architecture or behavior changes.
+- `docs/ARCHITECTURE.md`, `docs/STATE_MACHINE.md`, and `docs/WORKFLOW.md` for implemented workflow and recovery behavior.
+- `CLAUDE.md` and `AGENTS.md` for setup, validation, and repo-specific development rules.
+
+If `CONTEXT.md`, `CONTEXT-MAP.md`, or `docs/adr/` are added later, read the relevant files before architecture or implementation work.
+
+## Vocabulary
+
+Use the project's existing domain terms in issues and PRDs:
+
+- Job: a persistent proofreading task.
+- Chunk: a line-bounded unit processed independently.
+- Phase: the workflow stage, currently `validate`, `process`, `merge`, or `done`.
+- Job state: the visible lifecycle state, currently `queued`, `running`, `paused`, `done`, `error`, or `cancelled`.
+- UI attach: the browser-side association with a job id.
+- Reset: the hard delete/cleanup action for a job.

--- a/docs/agents/issue-tracker.md
+++ b/docs/agents/issue-tracker.md
@@ -1,0 +1,21 @@
+# Issue Tracker: GitHub
+
+Issues and PRDs for this repo live as GitHub issues in `makoMakoGo/novel-proofer`. Use the `gh` CLI from inside the repository so it infers the correct remote.
+
+## Conventions
+
+- Issue titles must start with one of the repository title prefixes:
+  - `[Bug]`
+  - `[Feature]`
+  - `[Suggestion]`
+  - `[General]`
+- Create an issue with `gh issue create --title "..." --body "..."`.
+- Read an issue with `gh issue view <number> --comments`.
+- List issues with `gh issue list --state open --json number,title,body,labels,comments`.
+- Comment with `gh issue comment <number> --body "..."`.
+- Apply or remove labels with `gh issue edit <number> --add-label "..."` and `--remove-label "..."`.
+- Close with `gh issue close <number> --comment "..."`.
+
+## Publishing
+
+When an engineering skill says to publish a PRD or issue to the issue tracker, create a GitHub issue.

--- a/docs/agents/triage-labels.md
+++ b/docs/agents/triage-labels.md
@@ -1,0 +1,13 @@
+# Triage Labels
+
+The engineering skills speak in terms of five canonical triage roles. This file maps those roles to labels in this repo's GitHub issue tracker.
+
+| Label in skills | Label in tracker | Meaning |
+| --- | --- | --- |
+| `needs-triage` | `needs-triage` | Maintainer needs to evaluate this issue |
+| `needs-info` | `needs-info` | Waiting on reporter for more information |
+| `ready-for-agent` | `ready-for-agent` | Fully specified, ready for an AFK agent |
+| `ready-for-human` | `ready-for-human` | Requires human implementation |
+| `wontfix` | `wontfix` | Will not be actioned |
+
+When a skill mentions a role, use the corresponding tracker label.


### PR DESCRIPTION
## Summary by Sourcery

Document agent-oriented workflows and conventions for managing issues and domain context in the Novel Proofer repo.

Documentation:
- Add CLAUDE-facing guidance on agent skills for issue tracking, triage labels, and domain documentation usage.
- Introduce domain documentation describing Novel Proofer concepts and key reference files for architecture and workflow.
- Add GitHub issue tracker conventions for titles, gh CLI usage, and publishing PRDs/issues as GitHub issues.
- Define the mapping between canonical triage roles used by engineering skills and this repo's GitHub issue labels.