### PR TITLE
refactor(workflow): expose job snapshot contract

### DIFF
--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -557,12 +557,36 @@ class JobStore:
             # 已标记为 cancelled（删除任务/reset）的 job 不接受更新
             if st.state == "cancelled":
                 return
-            # started_at 只接受首次写入
-            if k == "started_at" and st.started_at is not None:
-                continue
-            # paused 状态不被 running 覆盖
-            if k == "state" and st.state == "paused" and v in {"queued", "running"}:
-                continue
+
+            requested_state = kwargs.get("state", st.state)
+            target_state = (
+                st.state
+                if st.state == "paused" and requested_state in {"queued", "running"}
+                else requested_state
+            )
+            target_wait_reason = kwargs.get(
+                "wait_reason",
+                st.wait_reason if target_state == "paused" else None,
+            )
+
+            # paused 必须携带显式 wait_reason；离开 paused 时清空 wait_reason
+            if target_state == "paused" and target_wait_reason is None:
+                raise ValueError("wait_reason is required when state is paused")
+            if target_state != "paused" and target_wait_reason is not None:
+                raise ValueError("wait_reason must be null unless state is paused")
+
+            for k, v in kwargs.items():
+                # started_at 只接受首次写入
+                if k == "started_at" and st.started_at is not None:
+                    continue
+                # paused 状态不被 running 覆盖
+                if k == "state" and st.state == "paused" and v in {"queued", "running"}:
+                    continue
+                setattr(st, k, v)
+
+            # 离开 paused 时清空 wait_reason
+            if st.state != "paused":
+                st.wait_reason = None
 
             # 标记 dirty：让后台线程批量落盘（避免每个 chunk 更新都做一次全量 snapshot + 写盘）
             self._persist_dirty.add(job_id)
@@ -576,6 +600,7 @@ class JobStore:
 **设计要点**：
 - 所有状态更新通过 `update()` / `update_chunk()` 方法（受锁保护）
 - 使用 snapshot 模式返回数据（避免外部修改内部状态）；区分 full snapshot 与 summary snapshot，避免轮询路径复制全部 `chunk_statuses`
+- API 快照暴露 `workflow_phase` / `execution_state` / `wait_reason` / `terminal_state` / `available_commands`，不把内部 `state` / `phase` 原样公开给前端判断
 - `is_cancelled()` / `is_paused()` 用于 worker 检查是否应该停止
 - 可选持久化：Job 快照写入 `output/.state/jobs/{job_id}.json`，用于重启恢复；快照损坏时会直接报错，不做静默修复
 - 持久化节流：后台线程合并写入（默认 5s 一次，可用 `NOVEL_PROOFER_JOB_PERSIST_INTERVAL_S` 覆盖），避免高并发 chunk 更新导致频繁磁盘 IO

--- a/docs/STATE_MACHINE.md
+++ b/docs/STATE_MACHINE.md
@@ -1,9 +1,10 @@
 # 状态机：Job / Phase / Chunk（含重试语义）
 
-本文描述 novel-proofer 的三层状态模型：
+本文描述 novel-proofer 的内部状态模型与公开 API 快照：
 
-- **Job 运行态（`job.state`）**：一个任务整体的生命周期（`queued|running|paused|done|error|cancelled`）。
-- **Job 阶段（`job.phase`）**：任务处于哪一段 workflow（`validate|process|merge|done`）。
+- **内部 Job 阶段（`JobStatus.phase`）**：任务处于哪一段 workflow（`validate|process|merge|done`）；API 暴露为 `workflow_phase`。
+- **内部 Job 运行态（`JobStatus.state`）**：持久化记录的底层生命周期（`queued|running|paused|done|error|cancelled`）；API 不再把它作为 `state` 字段公开。
+- **API Job 快照**：UI 使用 `workflow_phase`、`execution_state`、`wait_reason`、`terminal_state` 与 `available_commands` 渲染，不从内部 `paused` 推断业务语义。
 - **Chunk 状态**：任务内每个分片的生命周期（`pending|processing|retrying|done|error`）。
 
 > 设计原则：`retrying` **不是**“待重试队列”，而是**同一次分片处理内部**的“自动重试/退避等待”中间态；手动“重试失败分片”应当把分片重置为 `pending` 再重新调度。
@@ -50,14 +51,14 @@ stateDiagram-v2
 
 ## Job 状态机
 
-### Job 阶段语义（`job.phase`）
+### 内部 Job 阶段语义（`JobStatus.phase` / API `workflow_phase`）
 
 - `validate`：校验/准备阶段：解码、切片、确定性规则预处理，生成可恢复中间态（`pre/` 等）。
 - `process`：处理阶段：对 chunk 发起 LLM 请求与校验，写入 `out/`；`resp/` 为可选调试产物（默认仅失败写入，或显式开启“全量保留 raw 响应”时写入）；失败支持自动重试与手动重试失败分片。
 - `merge`：合并阶段：所有 chunk 成功后，等待用户显式点击“合并输出”。
 - `done`：完成：已合并生成最终输出文件。
 
-### Job 运行态语义（`job.state`）
+### 内部 Job 运行态语义（`JobStatus.state`）
 
 - `queued`：已提交任务/准备开始（等待后台线程池调度）。
 - `running`：正在运行（校验/处理/合并任一阶段的后台任务正在执行）。
@@ -65,6 +66,14 @@ stateDiagram-v2
 - `error`：任务失败（通常是处理阶段存在 `chunk=error`；或合并阶段异常）。
 - `done`：任务完成（已合并生成输出）。
 - `cancelled`：仅用于“删除任务（reset）”的硬删除信号，通常会很快被清理并从 jobs 列表消失；UI 不应把它当作可恢复状态。
+
+### API Job 快照语义
+
+- `workflow_phase`：公开的 workflow 阶段，取代旧响应中的 `phase`。
+- `execution_state`：当前后端进程内的执行状态。`queued|running` 表示有执行尝试；`idle` 表示当前没有后台执行在跑。
+- `wait_reason`：解释一个可恢复 idle 任务为什么停住，只在内部 `paused` 状态下非空。当前取值包括 `ready_to_process`、`user_paused`、`ready_to_merge`、`server_recovered`。
+- `terminal_state`：终态投影。未结束时为 `null`；结束后为 `done|error|cancelled`。
+- `available_commands`：后端给 UI 的显式命令列表。UI 按这个列表决定按钮可用性，不再手写 `state=paused && phase=...` 之类的猜测。
 
 ### Mermaid（Job）
 
@@ -107,5 +116,5 @@ stateDiagram-v2
 
 - `retrying` 在**展示层**应视为 `processing` 的子状态：进度条与“处理中”统计/过滤可把 `processing + retrying` 合并为 “Active/处理中”。
 - 表格行内仍保留诊断能力：通过 `重试次数` 与 `信息(last_error_*)` 表达“正在重试/曾重试/最终错误”。
-- 主流程按钮推荐按 `job.phase` 呈现为：**开始校验 / 开始处理 / 合并输出**；并将“新任务（detach）”与“删除任务（reset）”区分（校对进行中建议先“暂停”再执行这两类操作）。
-- 为避免页面关闭/刷新导致 LLM 继续运行消耗时间/费用，UI 可在退出时调用一次 `/pause`（仅对 `phase=process` 生效）；如果请求没有送达，任务就会继续运行。
+- 主流程按钮按 `available_commands` 呈现为：**开始校验 / 开始处理 / 合并输出 / 下载 / 暂停 / 重试失败分片**；并将“新任务（detach）”与“删除任务（reset）”区分。
+- 刷新、关闭页面、隐藏页面与导航离开只改变浏览器侧 attachment，不应暂停、重置、取消或 abort 后端任务；停止工作必须来自用户显式点击命令。

--- a/docs/WORKFLOW_RECOVERY_REFACTOR.md
+++ b/docs/WORKFLOW_RECOVERY_REFACTOR.md
@@ -71,11 +71,13 @@ It does not own backend job lifecycle. Browser refresh, close, hidden, or naviga
 
 The API snapshot should expose enough information for the UI to render without guessing from `paused`.
 
-Required meanings:
+Implemented snapshot fields:
 
-- `phase`: where the durable workflow is, such as validate, process, merge, or done.
+- `workflow_phase`: where the durable workflow is, such as validate, process, merge, or done.
 - `execution_state`: whether this backend process currently has an execution attempt for the job.
 - `wait_reason`: why a durable job is idle.
+- `terminal_state`: whether the job has reached done, error, or cancelled.
+- `available_commands`: the explicit commands the UI may present.
 
 Recommended wait reasons:
 
@@ -84,7 +86,7 @@ Recommended wait reasons:
 - `ready_to_merge`: processing completed and the job is waiting for merge.
 - `server_recovered`: the backend restarted after a previously active job, and no execution is currently running.
 
-The implementation may choose exact field names in the API snapshot issue, but the meanings must remain separable.
+The UI must consume these fields directly instead of reconstructing behavior from the internal persisted `state` and `phase`.
 
 ## Browser Lifecycle
 

--- a/docs/openapi.json
+++ b/docs/openapi.json
@@ -328,6 +328,13 @@
       },
       "JobOut": {
         "properties": {
+          "available_commands": {
+            "items": {
+              "type": "string"
+            },
+            "title": "Available Commands",
+            "type": "array"
+          },
           "cleanup_debug_dir": {
             "default": true,
             "title": "Cleanup Debug Dir",
@@ -351,6 +358,10 @@
               }
             ],
             "title": "Error"
+          },
+          "execution_state": {
+            "title": "Execution State",
+            "type": "string"
           },
           "finished_at": {
             "anyOf": [
@@ -416,10 +427,6 @@
             ],
             "title": "Output Path"
           },
-          "phase": {
-            "title": "Phase",
-            "type": "string"
-          },
           "progress": {
             "$ref": "#/components/schemas/JobProgress"
           },
@@ -434,22 +441,44 @@
             ],
             "title": "Started At"
           },
-          "state": {
-            "title": "State",
-            "type": "string"
-          },
           "stats": {
             "additionalProperties": {
               "type": "integer"
             },
             "title": "Stats",
             "type": "object"
+          },
+          "terminal_state": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Terminal State"
+          },
+          "wait_reason": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Wait Reason"
+          },
+          "workflow_phase": {
+            "title": "Workflow Phase",
+            "type": "string"
           }
         },
         "required": [
           "id",
-          "state",
-          "phase",
+          "workflow_phase",
+          "execution_state",
           "created_at",
           "started_at",
           "finished_at",
@@ -488,9 +517,20 @@
       },
       "JobSummaryOut": {
         "properties": {
+          "available_commands": {
+            "items": {
+              "type": "string"
+            },
+            "title": "Available Commands",
+            "type": "array"
+          },
           "created_at": {
             "title": "Created At",
             "type": "number"
+          },
+          "execution_state": {
+            "title": "Execution State",
+            "type": "string"
           },
           "id": {
             "title": "Id",
@@ -526,22 +566,40 @@
             "title": "Output Filename",
             "type": "string"
           },
-          "phase": {
-            "title": "Phase",
-            "type": "string"
-          },
           "progress": {
             "$ref": "#/components/schemas/JobProgress"
           },
-          "state": {
-            "title": "State",
+          "terminal_state": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Terminal State"
+          },
+          "wait_reason": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Wait Reason"
+          },
+          "workflow_phase": {
+            "title": "Workflow Phase",
             "type": "string"
           }
         },
         "required": [
           "id",
-          "state",
-          "phase",
+          "workflow_phase",
+          "execution_state",
           "created_at",
           "input_filename",
           "output_filename",

--- a/novel_proofer/api.py
+++ b/novel_proofer/api.py
@@ -19,6 +19,7 @@ from novel_proofer.converters import (
     _chunk_to_out,
     _error,
     _format_from_options,
+    _job_summary_to_out,
     _job_to_out,
     _llm_from_options,
     _llm_settings_from_defaults,
@@ -45,7 +46,6 @@ from novel_proofer.models import (
     JobGetResponse,
     JobListResponse,
     JobOptions,
-    JobProgress,
     JobSummaryOut,
     LLMOptions,
     LLMSettingsPutRequest,
@@ -495,23 +495,7 @@ async def list_jobs(
         st_phase = st.phase.lower()
         if wanted_phases and st_phase not in wanted_phases:
             continue
-        out.append(
-            JobSummaryOut(
-                id=st.job_id,
-                state=st.state,
-                phase=st_phase or JobPhase.VALIDATE,
-                created_at=st.created_at,
-                input_filename=st.input_filename,
-                output_filename=st.output_filename,
-                progress=JobProgress(
-                    total_chunks=int(st.total_chunks or 0),
-                    done_chunks=int(st.done_chunks or 0),
-                    percent=int((st.done_chunks / st.total_chunks) * 100) if st.total_chunks else 0,
-                ),
-                last_error_code=st.last_error_code,
-                llm_model=st.last_llm_model,
-            )
-        )
+        out.append(_job_summary_to_out(st))
 
     if offset:
         out = out[offset:]

--- a/novel_proofer/converters.py
+++ b/novel_proofer/converters.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 import json
 import re
 import uuid
+from dataclasses import dataclass
 from pathlib import Path
 
 from fastapi import HTTPException, Request
@@ -19,15 +20,25 @@ from novel_proofer.models import (
     JobOptions,
     JobOut,
     JobProgress,
+    JobSummaryOut,
     LLMOptions,
     LLMSettings,
 )
 from novel_proofer.paths import _rel_debug_dir, _rel_output_path
-from novel_proofer.states import JobState
+from novel_proofer.states import ExecutionState, JobCommand, JobPhase, JobState, TerminalState
 
 _INTERNAL_ERROR_MESSAGE = "internal server error"
 
 _REQUEST_ID_RE = re.compile(r"^[A-Za-z0-9._-]{1,64}$")
+
+
+@dataclass(frozen=True)
+class _JobSnapshotFields:
+    workflow_phase: str
+    execution_state: str
+    wait_reason: str | None
+    terminal_state: str | None
+    available_commands: list[str]
 
 
 def _error_code_for_status(status_code: int) -> str:
@@ -73,10 +84,14 @@ def _job_to_out(st: JobStatus) -> JobOut:
         output_path = _rel_output_path(Path(st.output_path))
 
     fmt = st.format
+    snapshot = _job_snapshot_fields(st)
     return JobOut(
         id=st.job_id,
-        state=st.state,
-        phase=st.phase,
+        workflow_phase=snapshot.workflow_phase,
+        execution_state=snapshot.execution_state,
+        wait_reason=snapshot.wait_reason,
+        terminal_state=snapshot.terminal_state,
+        available_commands=snapshot.available_commands,
         created_at=st.created_at,
         started_at=st.started_at,
         finished_at=st.finished_at,
@@ -103,6 +118,83 @@ def _job_to_out(st: JobStatus) -> JobOut:
         stats=dict(st.stats),
         error=st.error,
         cleanup_debug_dir=st.cleanup_debug_dir,
+    )
+
+
+def _job_summary_to_out(st: JobStatus) -> JobSummaryOut:
+    pct = 0
+    if st.total_chunks > 0:
+        pct = int((st.done_chunks / st.total_chunks) * 100)
+
+    snapshot = _job_snapshot_fields(st)
+    return JobSummaryOut(
+        id=st.job_id,
+        workflow_phase=snapshot.workflow_phase,
+        execution_state=snapshot.execution_state,
+        wait_reason=snapshot.wait_reason,
+        terminal_state=snapshot.terminal_state,
+        available_commands=snapshot.available_commands,
+        created_at=st.created_at,
+        input_filename=st.input_filename,
+        output_filename=st.output_filename,
+        progress=JobProgress(total_chunks=st.total_chunks, done_chunks=st.done_chunks, percent=pct),
+        last_error_code=st.last_error_code,
+        llm_model=st.last_llm_model,
+    )
+
+
+def _job_snapshot_fields(st: JobStatus) -> _JobSnapshotFields:
+    state = JobState(st.state)
+    phase = JobPhase(st.phase)
+    execution_state = ExecutionState.IDLE
+    terminal_state: TerminalState | None = None
+    wait_reason: str | None = None
+
+    if state == JobState.QUEUED:
+        execution_state = ExecutionState.QUEUED
+    elif state == JobState.RUNNING:
+        execution_state = ExecutionState.RUNNING
+    elif state == JobState.PAUSED:
+        wait_reason = str(st.wait_reason or "")
+        if not wait_reason:
+            raise ValueError("paused job snapshot requires wait_reason")
+    elif state == JobState.DONE:
+        terminal_state = TerminalState.DONE
+    elif state == JobState.ERROR:
+        terminal_state = TerminalState.ERROR
+    elif state == JobState.CANCELLED:
+        terminal_state = TerminalState.CANCELLED
+    else:
+        raise ValueError(f"unknown job state: {state}")
+
+    commands: list[JobCommand] = []
+    chunk_counts = dict(st.chunk_counts or {})
+    failed_chunks = int(chunk_counts.get("error", 0) or 0)
+    all_chunks_done = st.total_chunks > 0 and int(chunk_counts.get("done", 0) or 0) == st.total_chunks
+
+    if state == JobState.PAUSED and phase == JobPhase.VALIDATE:
+        commands.append(JobCommand.VALIDATE)
+    if state == JobState.PAUSED and phase == JobPhase.PROCESS:
+        commands.append(JobCommand.PROCESS)
+    if state in {JobState.QUEUED, JobState.RUNNING} and phase == JobPhase.PROCESS:
+        commands.append(JobCommand.PAUSE)
+    if state == JobState.ERROR and failed_chunks > 0:
+        commands.append(JobCommand.RETRY_FAILED)
+    if state == JobState.PAUSED and phase == JobPhase.MERGE and all_chunks_done:
+        commands.append(JobCommand.MERGE)
+    if state not in {JobState.QUEUED, JobState.RUNNING, JobState.CANCELLED}:
+        commands.append(JobCommand.DETACH)
+    if state != JobState.CANCELLED:
+        commands.append(JobCommand.RESET)
+    if state == JobState.DONE:
+        commands.append(JobCommand.DOWNLOAD)
+
+    return _JobSnapshotFields(
+        workflow_phase=phase.value,
+        execution_state=execution_state.value,
+        wait_reason=wait_reason,
+        terminal_state=terminal_state.value if terminal_state is not None else None,
+        available_commands=[command.value for command in commands],
     )
 
 

--- a/novel_proofer/converters.py
+++ b/novel_proofer/converters.py
@@ -25,7 +25,7 @@ from novel_proofer.models import (
     LLMSettings,
 )
 from novel_proofer.paths import _rel_debug_dir, _rel_output_path
-from novel_proofer.states import ExecutionState, JobCommand, JobPhase, JobState, TerminalState
+from novel_proofer.states import ExecutionState, JobCommand, JobPhase, JobState, TerminalState, WaitReason
 
 _INTERNAL_ERROR_MESSAGE = "internal server error"
 
@@ -143,30 +143,7 @@ def _job_summary_to_out(st: JobStatus) -> JobSummaryOut:
     )
 
 
-def _job_snapshot_fields(st: JobStatus) -> _JobSnapshotFields:
-    state = JobState(st.state)
-    phase = JobPhase(st.phase)
-    execution_state = ExecutionState.IDLE
-    terminal_state: TerminalState | None = None
-    wait_reason: str | None = None
-
-    if state == JobState.QUEUED:
-        execution_state = ExecutionState.QUEUED
-    elif state == JobState.RUNNING:
-        execution_state = ExecutionState.RUNNING
-    elif state == JobState.PAUSED:
-        wait_reason = str(st.wait_reason or "")
-        if not wait_reason:
-            raise ValueError("paused job snapshot requires wait_reason")
-    elif state == JobState.DONE:
-        terminal_state = TerminalState.DONE
-    elif state == JobState.ERROR:
-        terminal_state = TerminalState.ERROR
-    elif state == JobState.CANCELLED:
-        terminal_state = TerminalState.CANCELLED
-    else:
-        raise ValueError(f"unknown job state: {state}")
-
+def _available_commands(st: JobStatus, *, state: JobState, phase: JobPhase) -> list[str]:
     commands: list[JobCommand] = []
     chunk_counts = dict(st.chunk_counts or {})
     failed_chunks = int(chunk_counts.get("error", 0) or 0)
@@ -189,12 +166,37 @@ def _job_snapshot_fields(st: JobStatus) -> _JobSnapshotFields:
     if state == JobState.DONE:
         commands.append(JobCommand.DOWNLOAD)
 
+    return [command.value for command in commands]
+
+
+def _terminal_state_for(state: JobState) -> TerminalState | None:
+    if state in {JobState.DONE, JobState.ERROR, JobState.CANCELLED}:
+        return TerminalState(state.value)
+    return None
+
+
+def _job_snapshot_fields(st: JobStatus) -> _JobSnapshotFields:
+    state = JobState(st.state)
+    phase = JobPhase(st.phase)
+    execution_state = ExecutionState.IDLE
+    terminal_state = _terminal_state_for(state)
+    wait_reason: str | None = None
+
+    if state == JobState.QUEUED:
+        execution_state = ExecutionState.QUEUED
+    elif state == JobState.RUNNING:
+        execution_state = ExecutionState.RUNNING
+    elif state == JobState.PAUSED:
+        if st.wait_reason is None:
+            raise ValueError("paused job snapshot requires wait_reason")
+        wait_reason = WaitReason(st.wait_reason).value
+
     return _JobSnapshotFields(
         workflow_phase=phase.value,
         execution_state=execution_state.value,
         wait_reason=wait_reason,
         terminal_state=terminal_state.value if terminal_state is not None else None,
-        available_commands=[command.value for command in commands],
+        available_commands=_available_commands(st, state=state, phase=phase),
     )
 
 

--- a/novel_proofer/jobs.py
+++ b/novel_proofer/jobs.py
@@ -776,27 +776,35 @@ class JobStore:
                 return
             if st.state == JobState.CANCELLED:
                 return
-            requested_state = kwargs.get("state", st.state)
+            requested_state = str(kwargs.get("state", st.state))
+            if requested_state not in _JOB_STATES:
+                raise ValueError(f"JobStore.update: state must be one of {sorted(_JOB_STATES)!r}")
             target_state = (
-                st.state
-                if st.state == JobState.PAUSED and requested_state in {JobState.QUEUED, JobState.RUNNING}
+                str(st.state)
+                if str(st.state) == JobState.PAUSED.value
+                and requested_state in {JobState.QUEUED.value, JobState.RUNNING.value}
                 else requested_state
             )
-            target_wait_reason = kwargs.get("wait_reason", st.wait_reason if target_state == JobState.PAUSED else None)
-            if target_state == JobState.PAUSED and target_wait_reason is None:
+            raw_wait_reason = kwargs.get(
+                "wait_reason", st.wait_reason if target_state == JobState.PAUSED.value else None
+            )
+            target_wait_reason = None if raw_wait_reason is None else str(raw_wait_reason)
+            if target_wait_reason is not None and target_wait_reason not in _WAIT_REASONS:
+                raise ValueError(f"JobStore.update: wait_reason must be one of {sorted(_WAIT_REASONS)!r}")
+            if target_state == JobState.PAUSED.value and target_wait_reason is None:
                 raise ValueError("JobStore.update: wait_reason is required when state is paused")
-            if target_state != JobState.PAUSED and target_wait_reason is not None:
+            if target_state != JobState.PAUSED.value and target_wait_reason is not None:
                 raise ValueError("JobStore.update: wait_reason must be None unless state is paused")
-            for k, v in kwargs.items():
+            normalized = dict(kwargs)
+            if "state" in normalized:
+                normalized["state"] = target_state
+            normalized["wait_reason"] = target_wait_reason if target_state == JobState.PAUSED.value else None
+            for k, v in normalized.items():
                 if k == "started_at" and st.started_at is not None and v is not None:
                     continue
-                if k == "state" and st.state == JobState.PAUSED and v in {JobState.QUEUED, JobState.RUNNING}:
-                    continue
-                if k == "state" and v in {JobState.DONE, JobState.ERROR, JobState.CANCELLED}:
+                if k == "state" and str(v) in {JobState.DONE.value, JobState.ERROR.value, JobState.CANCELLED.value}:
                     self._paused.discard(job_id)
                 setattr(st, k, v)
-            if st.state != JobState.PAUSED:
-                st.wait_reason = None
             self._mark_dirty_locked(job_id)
             flush_now = st.state in {JobState.DONE, JobState.ERROR, JobState.CANCELLED}
         if flush_now:

--- a/novel_proofer/jobs.py
+++ b/novel_proofer/jobs.py
@@ -14,16 +14,17 @@ from typing import Any
 
 from novel_proofer.env import env_float
 from novel_proofer.formatting.config import FormatConfig
-from novel_proofer.states import ChunkState, JobPhase, JobState
+from novel_proofer.states import ChunkState, JobPhase, JobState, WaitReason
 from novel_proofer.workflow import WorkflowInvariantError, validate_job_phase_invariants
 
 logger = logging.getLogger(__name__)
 
-_JOB_STATE_VERSION = 2
+_JOB_STATE_VERSION = 3
 _JOB_ID_RE = re.compile(r"^[0-9a-f]{32}$", re.IGNORECASE)
 
 _JOB_PHASES = {phase.value for phase in JobPhase}
 _JOB_STATES = {state.value for state in JobState}
+_WAIT_REASONS = {reason.value for reason in WaitReason}
 _CHUNK_STATE_VALUES = {state.value for state in ChunkState}
 _CHUNK_STATES = (
     ChunkState.PENDING,
@@ -36,6 +37,7 @@ _CHUNK_STATES = (
 _ALLOWED_JOB_UPDATE_FIELDS = {
     "state",
     "phase",
+    "wait_reason",
     "started_at",
     "finished_at",
     "output_filename",
@@ -94,6 +96,8 @@ class JobStatus:
     state: str
     # validate|process|merge|done
     phase: str
+    # ready_to_process|user_paused|ready_to_merge|server_recovered when state=paused; otherwise None
+    wait_reason: str | None
     created_at: float
     started_at: float | None
     finished_at: float | None
@@ -316,6 +320,7 @@ def _job_from_dict(d: dict[str, Any]) -> JobStatus:
             "job_id",
             "state",
             "phase",
+            "wait_reason",
             "created_at",
             "started_at",
             "finished_at",
@@ -360,6 +365,13 @@ def _job_from_dict(d: dict[str, Any]) -> JobStatus:
 
     state = _parse_enum(_require_field(job, "state", context="job"), context="job.state", allowed=_JOB_STATES)
     phase = _parse_enum(_require_field(job, "phase", context="job"), context="job.phase", allowed=_JOB_PHASES)
+    wait_reason = _parse_optional_str(job.get("wait_reason"), context="job.wait_reason")
+    if wait_reason is not None and wait_reason not in _WAIT_REASONS:
+        raise ValueError(f"job.wait_reason must be one of {sorted(_WAIT_REASONS)!r}")
+    if state == JobState.PAUSED and wait_reason is None:
+        raise ValueError("job.wait_reason is required when job.state is 'paused'")
+    if state != JobState.PAUSED and wait_reason is not None:
+        raise ValueError("job.wait_reason must be null unless job.state is 'paused'")
     try:
         validate_job_phase_invariants(state, phase, [chunk.state for chunk in chunks])
     except WorkflowInvariantError as e:
@@ -374,6 +386,7 @@ def _job_from_dict(d: dict[str, Any]) -> JobStatus:
         job_id=job_id,
         state=state,
         phase=phase,
+        wait_reason=wait_reason,
         created_at=_parse_float(_require_field(job, "created_at", context="job"), context="job.created_at"),
         started_at=_parse_optional_float(job.get("started_at"), context="job.started_at"),
         finished_at=_parse_optional_float(job.get("finished_at"), context="job.finished_at"),
@@ -595,6 +608,7 @@ class JobStore:
         if st.state in {JobState.QUEUED, JobState.RUNNING}:
             logger.warning("restoring in-flight job as paused after restart: job_id=%s state=%s", st.job_id, st.state)
             st.state = JobState.PAUSED
+            st.wait_reason = WaitReason.SERVER_RECOVERED
             st.finished_at = None
             changed = True
 
@@ -652,6 +666,7 @@ class JobStore:
             job_id=st.job_id,
             state=st.state,
             phase=st.phase,
+            wait_reason=st.wait_reason,
             created_at=st.created_at,
             started_at=st.started_at,
             finished_at=st.finished_at,
@@ -678,6 +693,7 @@ class JobStore:
             job_id=job_id,
             state=JobState.QUEUED,
             phase=JobPhase.VALIDATE,
+            wait_reason=None,
             created_at=time.time(),
             started_at=None,
             finished_at=None,
@@ -760,6 +776,17 @@ class JobStore:
                 return
             if st.state == JobState.CANCELLED:
                 return
+            requested_state = kwargs.get("state", st.state)
+            target_state = (
+                st.state
+                if st.state == JobState.PAUSED and requested_state in {JobState.QUEUED, JobState.RUNNING}
+                else requested_state
+            )
+            target_wait_reason = kwargs.get("wait_reason", st.wait_reason if target_state == JobState.PAUSED else None)
+            if target_state == JobState.PAUSED and target_wait_reason is None:
+                raise ValueError("JobStore.update: wait_reason is required when state is paused")
+            if target_state != JobState.PAUSED and target_wait_reason is not None:
+                raise ValueError("JobStore.update: wait_reason must be None unless state is paused")
             for k, v in kwargs.items():
                 if k == "started_at" and st.started_at is not None and v is not None:
                     continue
@@ -768,6 +795,8 @@ class JobStore:
                 if k == "state" and v in {JobState.DONE, JobState.ERROR, JobState.CANCELLED}:
                     self._paused.discard(job_id)
                 setattr(st, k, v)
+            if st.state != JobState.PAUSED:
+                st.wait_reason = None
             self._mark_dirty_locked(job_id)
             flush_now = st.state in {JobState.DONE, JobState.ERROR, JobState.CANCELLED}
         if flush_now:
@@ -856,6 +885,7 @@ class JobStore:
             # Update visible state immediately so clients can stop polling.
             if st.state not in {JobState.DONE, JobState.ERROR}:
                 st.state = JobState.CANCELLED
+                st.wait_reason = None
                 st.finished_at = now
 
             for i, cs in enumerate(st.chunk_statuses):
@@ -883,6 +913,7 @@ class JobStore:
 
             self._paused.add(job_id)
             st.state = JobState.PAUSED
+            st.wait_reason = WaitReason.USER_PAUSED
             st.finished_at = None
             self._mark_dirty_locked(job_id)
         return True
@@ -898,6 +929,7 @@ class JobStore:
             self._paused.discard(job_id)
             if st.state == JobState.PAUSED:
                 st.state = JobState.QUEUED
+                st.wait_reason = None
                 st.finished_at = None
             self._mark_dirty_locked(job_id)
         return True

--- a/novel_proofer/models.py
+++ b/novel_proofer/models.py
@@ -71,8 +71,11 @@ class JobProgress(BaseModel):
 
 class JobOut(BaseModel):
     id: str
-    state: str
-    phase: str
+    workflow_phase: str
+    execution_state: str
+    wait_reason: str | None = None
+    terminal_state: str | None = None
+    available_commands: list[str] = Field(default_factory=list)
     created_at: float
     started_at: float | None
     finished_at: float | None
@@ -129,8 +132,11 @@ class MergeRequest(BaseModel):
 
 class JobSummaryOut(BaseModel):
     id: str
-    state: str
-    phase: str
+    workflow_phase: str
+    execution_state: str
+    wait_reason: str | None = None
+    terminal_state: str | None = None
+    available_commands: list[str] = Field(default_factory=list)
     created_at: float
     input_filename: str
     output_filename: str

--- a/novel_proofer/runner.py
+++ b/novel_proofer/runner.py
@@ -582,7 +582,7 @@ def run_job(job_id: str, input_path: Path, fmt: FormatConfig, llm: LLMConfig) ->
             GLOBAL_JOBS.update(
                 job_id,
                 state=JobState.PAUSED,
-                phase=JobPhase.VALIDATE,
+                phase=JobPhase.PROCESS,
                 wait_reason=WaitReason.USER_PAUSED,
                 finished_at=None,
             )

--- a/novel_proofer/runner.py
+++ b/novel_proofer/runner.py
@@ -19,7 +19,7 @@ from novel_proofer.formatting.rules import apply_rules, is_chapter_title, is_sep
 from novel_proofer.jobs import GLOBAL_JOBS
 from novel_proofer.llm.client import LLMError, call_llm_text_resilient_with_meta_and_raw
 from novel_proofer.llm.config import LLMConfig, build_first_chunk_config
-from novel_proofer.states import ChunkState, JobPhase, JobState
+from novel_proofer.states import ChunkState, JobPhase, JobState, WaitReason
 from novel_proofer.workflow import ProcessingFinalState, processing_final_state
 
 logger = logging.getLogger(__name__)
@@ -253,6 +253,7 @@ def _finalize_processing(job_id: str, total: int, error_msg: str) -> bool:
         job_id,
         state=JobState.PAUSED,
         phase=JobPhase.MERGE,
+        wait_reason=WaitReason.READY_TO_MERGE,
         finished_at=None,
         error=None,
         done_chunks=total,
@@ -554,7 +555,13 @@ def run_job(job_id: str, input_path: Path, fmt: FormatConfig, llm: LLMConfig) ->
                 GLOBAL_JOBS.update(job_id, state=JobState.CANCELLED, finished_at=time.time())
                 return
             if GLOBAL_JOBS.is_paused(job_id):
-                GLOBAL_JOBS.update(job_id, state=JobState.PAUSED, phase=JobPhase.VALIDATE, finished_at=None)
+                GLOBAL_JOBS.update(
+                    job_id,
+                    state=JobState.PAUSED,
+                    phase=JobPhase.VALIDATE,
+                    wait_reason=WaitReason.USER_PAUSED,
+                    finished_at=None,
+                )
                 return
 
             pre_fmt = replace(fmt, paragraph_indent=False)
@@ -572,10 +579,23 @@ def run_job(job_id: str, input_path: Path, fmt: FormatConfig, llm: LLMConfig) ->
             GLOBAL_JOBS.update(job_id, state=JobState.CANCELLED, finished_at=time.time())
             return
         if GLOBAL_JOBS.is_paused(job_id):
-            GLOBAL_JOBS.update(job_id, state=JobState.PAUSED, phase=JobPhase.VALIDATE, finished_at=None)
+            GLOBAL_JOBS.update(
+                job_id,
+                state=JobState.PAUSED,
+                phase=JobPhase.VALIDATE,
+                wait_reason=WaitReason.USER_PAUSED,
+                finished_at=None,
+            )
             return
 
-        GLOBAL_JOBS.update(job_id, state=JobState.PAUSED, phase=JobPhase.PROCESS, finished_at=None, error=None)
+        GLOBAL_JOBS.update(
+            job_id,
+            state=JobState.PAUSED,
+            phase=JobPhase.PROCESS,
+            wait_reason=WaitReason.READY_TO_PROCESS,
+            finished_at=None,
+            error=None,
+        )
     except Exception as e:
         if GLOBAL_JOBS.is_cancelled(job_id):
             GLOBAL_JOBS.update(job_id, state=JobState.CANCELLED, finished_at=time.time())
@@ -630,7 +650,13 @@ def retry_failed_chunks(job_id: str, llm: LLMConfig) -> None:
         GLOBAL_JOBS.update(job_id, state=JobState.CANCELLED, finished_at=time.time())
         return
     if outcome == "paused" or GLOBAL_JOBS.is_paused(job_id):
-        GLOBAL_JOBS.update(job_id, state=JobState.PAUSED, phase=JobPhase.PROCESS, finished_at=None)
+        GLOBAL_JOBS.update(
+            job_id,
+            state=JobState.PAUSED,
+            phase=JobPhase.PROCESS,
+            wait_reason=WaitReason.USER_PAUSED,
+            finished_at=None,
+        )
         return
     _post_llm_deterministic_pass(job_id, work_dir)
     _finalize_processing(job_id, total, "some chunks still failed; update LLM config and retry again")
@@ -675,7 +701,13 @@ def resume_paused_job(job_id: str, llm: LLMConfig) -> None:
         GLOBAL_JOBS.update(job_id, state=JobState.CANCELLED, finished_at=time.time())
         return
     if outcome == "paused" or GLOBAL_JOBS.is_paused(job_id):
-        GLOBAL_JOBS.update(job_id, state=JobState.PAUSED, phase=JobPhase.PROCESS, finished_at=None)
+        GLOBAL_JOBS.update(
+            job_id,
+            state=JobState.PAUSED,
+            phase=JobPhase.PROCESS,
+            wait_reason=WaitReason.USER_PAUSED,
+            finished_at=None,
+        )
         return
 
     _post_llm_deterministic_pass(job_id, work_dir)

--- a/novel_proofer/states.py
+++ b/novel_proofer/states.py
@@ -12,6 +12,36 @@ class JobState(StrEnum):
     CANCELLED = "cancelled"
 
 
+class ExecutionState(StrEnum):
+    IDLE = "idle"
+    QUEUED = "queued"
+    RUNNING = "running"
+
+
+class WaitReason(StrEnum):
+    READY_TO_PROCESS = "ready_to_process"
+    USER_PAUSED = "user_paused"
+    READY_TO_MERGE = "ready_to_merge"
+    SERVER_RECOVERED = "server_recovered"
+
+
+class TerminalState(StrEnum):
+    DONE = "done"
+    ERROR = "error"
+    CANCELLED = "cancelled"
+
+
+class JobCommand(StrEnum):
+    VALIDATE = "validate"
+    PROCESS = "process"
+    PAUSE = "pause"
+    RETRY_FAILED = "retry_failed"
+    MERGE = "merge"
+    DETACH = "detach"
+    RESET = "reset"
+    DOWNLOAD = "download"
+
+
 class ChunkState(StrEnum):
     PENDING = "pending"
     PROCESSING = "processing"

--- a/templates/static/js/main.js
+++ b/templates/static/js/main.js
@@ -104,16 +104,32 @@ function ensurePolling(jobId, intervalMs) {
     state.pollTimer = setInterval(() => refreshJobOnce(jobId), ms);
 }
 
-function detachUi({ clearFile = true } = {}) {
-    stopPolling();
-    state.pollInFlight = false;
-
-    state.currentJobId = null;
+function clearCurrentJobSnapshot() {
     state.currentJobExecutionState = null;
     state.currentJobWorkflowPhase = null;
     state.currentJobWaitReason = null;
     state.currentJobTerminalState = null;
     state.currentJobCommands = [];
+}
+
+function jobLoadingSnapshot(jobId) {
+    return {
+        id: jobId,
+        execution_state: null,
+        workflow_phase: null,
+        wait_reason: null,
+        terminal_state: null,
+        available_commands: [],
+        progress: { done_chunks: 0, total_chunks: 0 },
+    };
+}
+
+function detachUi({ clearFile = true } = {}) {
+    stopPolling();
+    state.pollInFlight = false;
+
+    state.currentJobId = null;
+    clearCurrentJobSnapshot();
     setAttachedJobId(null);
 
     state.chunksData = [];
@@ -234,6 +250,12 @@ async function refreshJobOnce(jobId) {
 async function attachJob(jobId) {
     const jid = String(jobId || '').trim();
     if (!jid) return;
+    const switchingJob = state.currentJobId !== jid;
+    if (switchingJob) {
+        stopPolling();
+        state.pollInFlight = false;
+        clearCurrentJobSnapshot();
+    }
     state.currentJobId = jid;
     setAttachedJobId(jid);
 
@@ -244,6 +266,12 @@ async function attachJob(jobId) {
     state.lastChunksFetchAtMs = 0;
     ui.updateStats();
     ui.renderChunksTable();
+    const loadingJob = jobLoadingSnapshot(jid);
+    ui.setJobCard(loadingJob);
+    ui.setProgressFromJob(null);
+    ui.refreshLocks(loadingJob);
+    ui.refreshActionButtons(loadingJob);
+    ui.refreshSourcePanelFromJob(loadingJob);
 
     ensurePolling(jid, PROCESS_POLL_MS);
     await refreshJobOnce(jid);

--- a/templates/static/js/main.js
+++ b/templates/static/js/main.js
@@ -109,8 +109,11 @@ function detachUi({ clearFile = true } = {}) {
     state.pollInFlight = false;
 
     state.currentJobId = null;
-    state.currentJobState = null;
-    state.currentJobPhase = null;
+    state.currentJobExecutionState = null;
+    state.currentJobWorkflowPhase = null;
+    state.currentJobWaitReason = null;
+    state.currentJobTerminalState = null;
+    state.currentJobCommands = [];
     setAttachedJobId(null);
 
     state.chunksData = [];
@@ -151,8 +154,11 @@ async function refreshJobOnce(jobId) {
         }
 
         const job = r?.data?.job;
-        state.currentJobState = job?.state || null;
-        state.currentJobPhase = job?.phase || null;
+        state.currentJobExecutionState = job?.execution_state || null;
+        state.currentJobWorkflowPhase = job?.workflow_phase || null;
+        state.currentJobWaitReason = job?.wait_reason || null;
+        state.currentJobTerminalState = job?.terminal_state || null;
+        state.currentJobCommands = Array.isArray(job?.available_commands) ? job.available_commands.map((v) => String(v)) : [];
 
         // Sync slice settings from job
         const fmt = job?.format || null;
@@ -188,20 +194,23 @@ async function refreshJobOnce(jobId) {
         if (state.activeTab !== 'debug') state.chunkCounts = null;
         ui.updateStats();
 
-        if (job?.state === 'error') {
+        if (job?.terminal_state === 'error') {
             ui.show(job?.error || '处理出错');
-        } else if (job?.state === 'paused' && job?.phase === 'process') {
-            const done = Number(job?.progress?.done_chunks || 0);
-            ui.show(done > 0 ? '校对已暂停：可点击“继续校对”。' : '预处理完成：可点击“开始校对”。');
-        } else if (job?.state === 'paused' && job?.phase === 'merge') {
+        } else if (job?.wait_reason === 'ready_to_process') {
+            ui.show('预处理完成：可点击“开始校对”。');
+        } else if (job?.wait_reason === 'user_paused') {
+            ui.show('校对已暂停：可点击“继续校对”。');
+        } else if (job?.wait_reason === 'ready_to_merge') {
             ui.show('校对完成：可点击“合并输出”。');
-        } else if (job?.state === 'done') {
+        } else if (job?.wait_reason === 'server_recovered') {
+            ui.show('服务重启后任务已恢复为等待状态，请确认后继续。');
+        } else if (job?.terminal_state === 'done') {
             ui.show(job?.output_path ? `完成。输出：${job.output_path}\n可点击“下载输出”或“新任务”。` : '完成。已输出到项目 output/ 目录。');
         }
 
-        const stLower = String(job?.state || '').toLowerCase();
-        const phaseLower = String(job?.phase || '').toLowerCase();
-        const shouldPoll = stLower === 'queued' || stLower === 'running';
+        const executionLower = String(job?.execution_state || '').toLowerCase();
+        const phaseLower = String(job?.workflow_phase || '').toLowerCase();
+        const shouldPoll = executionLower === 'queued' || executionLower === 'running';
         if (shouldPoll) {
             const nextMs = phaseLower === 'process' ? PROCESS_POLL_MS : NON_PROCESS_POLL_MS;
             ensurePolling(jobId, nextMs);
@@ -536,7 +545,7 @@ function bindJobActionEvents() {
             ui.elements.form.requestSubmit();
             return;
         }
-        if (state.currentJobState === 'paused' && state.currentJobPhase === 'validate') {
+        if (state.currentJobCommands.includes('validate')) {
             const jobId = state.currentJobId;
             ui.show('继续预处理…');
 
@@ -554,9 +563,9 @@ function bindJobActionEvents() {
     ui.elements.btnCancel?.addEventListener('click', async () => {
         const jobId = state.currentJobId;
         if (!jobId) return;
-        const st = String(state.currentJobState || '').toLowerCase();
-        const phase = String(state.currentJobPhase || '').toLowerCase();
-        const isRunning = st === 'queued' || st === 'running';
+        const execution = String(state.currentJobExecutionState || '').toLowerCase();
+        const phase = String(state.currentJobWorkflowPhase || '').toLowerCase();
+        const isRunning = execution === 'queued' || execution === 'running';
         if (isRunning) {
             if (phase === 'process') ui.show('校对进行中：请先“暂停”再开始新任务。');
             else ui.show('任务运行中：请等待完成后再开始新任务，或直接删除任务。');
@@ -569,16 +578,17 @@ function bindJobActionEvents() {
     ui.elements.btnReset?.addEventListener('click', async () => {
         const jobId = state.currentJobId;
         if (!jobId) return;
-        const st = String(state.currentJobState || '').toLowerCase();
-        const phase = String(state.currentJobPhase || '').toLowerCase();
+        const execution = String(state.currentJobExecutionState || '').toLowerCase();
+        const phase = String(state.currentJobWorkflowPhase || '').toLowerCase();
+        const terminal = String(state.currentJobTerminalState || '').toLowerCase();
 
-        if ((st === 'queued' || st === 'running') && phase === 'process') {
+        if ((execution === 'queued' || execution === 'running') && phase === 'process') {
             ui.show('校对进行中：请先“暂停”再删除任务。');
             return;
         }
 
-        const isRunning = st === 'queued' || st === 'running';
-        const isDone = st === 'done';
+        const isRunning = execution === 'queued' || execution === 'running';
+        const isDone = terminal === 'done';
         const isValidateRunning = isRunning && phase === 'validate';
         const isMergeRunning = isRunning && phase === 'merge';
         const phaseLabel = isValidateRunning ? '预处理' : (isMergeRunning ? '合并' : '');
@@ -591,7 +601,7 @@ function bindJobActionEvents() {
 
         if (!(await modal.showConfirm(confirmMsg))) return;
 
-        ui.show((st === 'done') ? '正在删除任务记录…' : '正在删除任务…');
+        ui.show(isDone ? '正在删除任务记录…' : '正在删除任务…');
         const r = await api.resetJob(jobId);
         if (!r.ok) { ui.show(r.error); return; }
 

--- a/templates/static/js/modal.js
+++ b/templates/static/js/modal.js
@@ -1,6 +1,8 @@
 
 // Modal logic
 
+import { snapshotLabel, snapshotTone } from './workflow.js';
+
 let modalCloseCallback = null;
 let modalCloseTimer = null;
 let modalToken = 0;
@@ -104,24 +106,18 @@ export function showJobPicker(jobs, { hasCurrentJob = false } = {}) {
         const listHtml = jobs.slice(0, 20).map((j) => {
             const jobId = escapeHtml(j?.id ? String(j.id) : '');
             const id8 = escapeHtml(j?.id ? String(j.id).slice(0, 8) : '-');
-            const execution = String(j?.execution_state || '').toLowerCase();
-            const terminal = j?.terminal_state == null ? null : String(j.terminal_state).toLowerCase();
-            const wait = j?.wait_reason == null ? null : String(j.wait_reason).toLowerCase();
             const phase = escapeHtml(j?.workflow_phase || '-');
-            const statusText = escapeHtml(terminal || wait || execution || '-');
+            const statusText = escapeHtml(snapshotLabel(j));
             const prog = escapeHtml(`${j?.progress?.done_chunks || 0}/${j?.progress?.total_chunks || 0}`);
             const name = escapeHtml(j?.input_filename ? String(j.input_filename) : '');
             
-            const statusKey = terminal || wait || execution;
-            const stColor = { 
-                done: 'bg-emerald-100 text-emerald-700', 
-                error: 'bg-red-100 text-red-700', 
-                ready_to_process: 'bg-amber-100 text-amber-700',
-                user_paused: 'bg-amber-100 text-amber-700',
-                ready_to_merge: 'bg-amber-100 text-amber-700',
-                server_recovered: 'bg-amber-100 text-amber-700',
-                cancelled: 'bg-slate-200 text-slate-600',
-            }[statusKey] || 'bg-slate-100 text-slate-600';
+            const stColor = {
+                wait: 'bg-amber-100 text-amber-700',
+                error: 'bg-red-100 text-red-700',
+                success: 'bg-emerald-100 text-emerald-700',
+                active: 'bg-slate-100 text-slate-600',
+                neutral: 'bg-slate-200 text-slate-600',
+            }[snapshotTone(j)] || 'bg-slate-100 text-slate-600';
 
             return `<button type="button" data-job-id="${jobId}" class="job-item w-full text-left px-3 py-2 rounded-lg hover:bg-slate-50 border border-slate-100 hover:border-slate-200 transition-colors flex items-center gap-3">
             <span class="font-mono text-xs text-slate-400">${id8}</span>

--- a/templates/static/js/modal.js
+++ b/templates/static/js/modal.js
@@ -104,21 +104,28 @@ export function showJobPicker(jobs, { hasCurrentJob = false } = {}) {
         const listHtml = jobs.slice(0, 20).map((j) => {
             const jobId = escapeHtml(j?.id ? String(j.id) : '');
             const id8 = escapeHtml(j?.id ? String(j.id).slice(0, 8) : '-');
-            const st = escapeHtml(j?.state || '-');
-            const phase = escapeHtml(j?.phase || '-');
+            const execution = String(j?.execution_state || '').toLowerCase();
+            const terminal = j?.terminal_state == null ? null : String(j.terminal_state).toLowerCase();
+            const wait = j?.wait_reason == null ? null : String(j.wait_reason).toLowerCase();
+            const phase = escapeHtml(j?.workflow_phase || '-');
+            const statusText = escapeHtml(terminal || wait || execution || '-');
             const prog = escapeHtml(`${j?.progress?.done_chunks || 0}/${j?.progress?.total_chunks || 0}`);
             const name = escapeHtml(j?.input_filename ? String(j.input_filename) : '');
             
+            const statusKey = terminal || wait || execution;
             const stColor = { 
                 done: 'bg-emerald-100 text-emerald-700', 
                 error: 'bg-red-100 text-red-700', 
-                paused: 'bg-amber-100 text-amber-700', 
-                cancelled: 'bg-slate-200 text-slate-600' 
-            }[j?.state] || 'bg-slate-100 text-slate-600';
+                ready_to_process: 'bg-amber-100 text-amber-700',
+                user_paused: 'bg-amber-100 text-amber-700',
+                ready_to_merge: 'bg-amber-100 text-amber-700',
+                server_recovered: 'bg-amber-100 text-amber-700',
+                cancelled: 'bg-slate-200 text-slate-600',
+            }[statusKey] || 'bg-slate-100 text-slate-600';
 
             return `<button type="button" data-job-id="${jobId}" class="job-item w-full text-left px-3 py-2 rounded-lg hover:bg-slate-50 border border-slate-100 hover:border-slate-200 transition-colors flex items-center gap-3">
             <span class="font-mono text-xs text-slate-400">${id8}</span>
-            <span class="text-xs px-1.5 py-0.5 rounded ${stColor}">${st}:${phase}</span>
+            <span class="text-xs px-1.5 py-0.5 rounded ${stColor}">${statusText}:${phase}</span>
             <span class="text-xs text-slate-500 font-mono">${prog}</span>
             <span class="text-sm text-slate-700 truncate flex-1">${name}</span>
           </button>`;

--- a/templates/static/js/state.js
+++ b/templates/static/js/state.js
@@ -3,8 +3,11 @@
 
 export const state = {
     currentJobId: null,
-    currentJobState: null,
-    currentJobPhase: null,
+    currentJobExecutionState: null,
+    currentJobWorkflowPhase: null,
+    currentJobWaitReason: null,
+    currentJobTerminalState: null,
+    currentJobCommands: [],
     currentFilter: 'all',
     activeTab: 'progress',
     chunksData: [],

--- a/templates/static/js/ui.js
+++ b/templates/static/js/ui.js
@@ -1,6 +1,6 @@
 
 import { state, UI_STATE_FIELDS } from './state.js';
-import { actionAvailability, primaryActionKey } from './workflow.js';
+import { actionAvailability, primaryActionKey, snapshotLabel, snapshotTone } from './workflow.js';
 
 // DOM Elements Cache
 export const elements = {};
@@ -340,33 +340,6 @@ export function setJobCard(job) {
     if (elements.jobInputName) elements.jobInputName.textContent = j?.input_filename ? String(j.input_filename) : '-';
 }
 
-function _stateLabel(s) {
-    const v = String(s || '').toLowerCase();
-    const map = { queued: '排队中', running: '运行中', idle: '空闲', done: '已完成', cancelled: '已删除', error: '出错' };
-    return map[v] || (v || '-');
-}
-
-function _snapshotLabel(job) {
-    const execution = String(job?.execution_state || '').toLowerCase();
-    const wait = job?.wait_reason == null ? null : String(job.wait_reason).toLowerCase();
-    const terminal = job?.terminal_state == null ? null : String(job.terminal_state).toLowerCase();
-
-    if (terminal) {
-        const labels = { done: '已完成', error: '出错', cancelled: '已删除' };
-        return labels[terminal] || `未知终态:${terminal}`;
-    }
-    if (execution === 'queued' || execution === 'running') return _stateLabel(execution);
-    if (execution !== 'idle') return `未知执行态:${execution || '-'}`;
-    if (!wait) return '空闲';
-    const waitLabels = {
-        ready_to_process: '等待开始校对',
-        user_paused: '已暂停',
-        ready_to_merge: '等待合并输出',
-        server_recovered: '服务重启后等待继续',
-    };
-    return waitLabels[wait] || `未知等待原因:${wait}`;
-}
-
 export function setProgressFromJob(job) {
     if (!job) {
         if (elements.progress) elements.progress.classList.add('hidden');
@@ -392,7 +365,7 @@ export function setProgressFromJob(job) {
         else elements.bar.classList.add('bg-ink');
     }
 
-    let left = _snapshotLabel(job);
+    let left = snapshotLabel(job);
     if (execution === 'queued' && phase === 'validate') left = '预处理排队中…';
     if (execution === 'running' && phase === 'validate') left = '正在预处理…';
     if (wait === 'ready_to_process') left = '预处理完成，等待开始校对';
@@ -440,7 +413,8 @@ const LLM_FIELDS = [
 
 export function refreshLocks(job) {
     const hasJob = !!job;
-    const llmLocked = hasJob && ['queued', 'running'].includes(String(job.execution_state || ''));
+    const execution = String(job?.execution_state || '').toLowerCase();
+    const llmLocked = hasJob && ['queued', 'running'].includes(execution);
 
     _setFieldsDisabled(SLICE_FIELDS, hasJob);
     if (elements.sliceLockHint) {
@@ -516,13 +490,15 @@ export function refreshWorkflowStepper(job) {
         let badgeText = '未开始';
         let badgeCls = 'text-xs text-slate-400';
         if (hasJob) {
-            badgeText = _snapshotLabel(job);
-            if (wait) badgeCls = 'text-xs text-amber-600';
-            else if (terminal === 'error') badgeCls = 'text-xs text-red-600';
-            else if (terminal === 'done') badgeCls = 'text-xs text-emerald-600';
-            else if (terminal === 'cancelled') badgeCls = 'text-xs text-slate-600';
-            else if (execution === 'queued' || execution === 'running') badgeCls = 'text-xs text-slate-500';
-            else badgeCls = 'text-xs text-slate-500';
+            const tone = snapshotTone(job);
+            badgeText = snapshotLabel(job);
+            badgeCls = {
+                wait: 'text-xs text-amber-600',
+                error: 'text-xs text-red-600',
+                success: 'text-xs text-emerald-600',
+                active: 'text-xs text-slate-500',
+                neutral: 'text-xs text-slate-500',
+            }[tone] || 'text-xs text-slate-500';
         }
         elements.wfStateBadge.textContent = badgeText;
         elements.wfStateBadge.className = badgeCls;

--- a/templates/static/js/ui.js
+++ b/templates/static/js/ui.js
@@ -342,8 +342,29 @@ export function setJobCard(job) {
 
 function _stateLabel(s) {
     const v = String(s || '').toLowerCase();
-    const map = { queued: '排队中', running: '运行中', paused: '已暂停', done: '已完成', cancelled: '已删除', error: '出错' };
+    const map = { queued: '排队中', running: '运行中', idle: '空闲', done: '已完成', cancelled: '已删除', error: '出错' };
     return map[v] || (v || '-');
+}
+
+function _snapshotLabel(job) {
+    const execution = String(job?.execution_state || '').toLowerCase();
+    const wait = job?.wait_reason == null ? null : String(job.wait_reason).toLowerCase();
+    const terminal = job?.terminal_state == null ? null : String(job.terminal_state).toLowerCase();
+
+    if (terminal) {
+        const labels = { done: '已完成', error: '出错', cancelled: '已删除' };
+        return labels[terminal] || `未知终态:${terminal}`;
+    }
+    if (execution === 'queued' || execution === 'running') return _stateLabel(execution);
+    if (execution !== 'idle') return `未知执行态:${execution || '-'}`;
+    if (!wait) return '空闲';
+    const waitLabels = {
+        ready_to_process: '等待开始校对',
+        user_paused: '已暂停',
+        ready_to_merge: '等待合并输出',
+        server_recovered: '服务重启后等待继续',
+    };
+    return waitLabels[wait] || `未知等待原因:${wait}`;
 }
 
 export function setProgressFromJob(job) {
@@ -354,29 +375,36 @@ export function setProgressFromJob(job) {
     }
 
     if (elements.progress) elements.progress.classList.remove('hidden');
-    const st = String(job.state || '').toLowerCase();
-    const phase = String(job.phase || '').toLowerCase();
+    const execution = String(job.execution_state || '').toLowerCase();
+    const phase = String(job.workflow_phase || '').toLowerCase();
+    const wait = job?.wait_reason == null ? null : String(job.wait_reason).toLowerCase();
+    const terminal = job?.terminal_state == null ? null : String(job.terminal_state).toLowerCase();
     const done = Number(job?.progress?.done_chunks || 0);
     const total = Number(job?.progress?.total_chunks || 0);
-    const pct = total > 0 ? Math.floor((done / total) * 100) : (st === 'done' ? 100 : 0);
+    const pct = total > 0 ? Math.floor((done / total) * 100) : (terminal === 'done' ? 100 : 0);
     
     if (elements.bar) {
         elements.bar.style.width = pct + '%';
         elements.bar.classList.remove('bg-ink', 'bg-amber-500', 'bg-red-500', 'bg-emerald-500');
-        if (st === 'error') elements.bar.classList.add('bg-red-500');
-        else if (st === 'paused') elements.bar.classList.add('bg-amber-500');
-        else if (st === 'done') elements.bar.classList.add('bg-emerald-500');
+        if (terminal === 'error') elements.bar.classList.add('bg-red-500');
+        else if (wait) elements.bar.classList.add('bg-amber-500');
+        else if (terminal === 'done') elements.bar.classList.add('bg-emerald-500');
         else elements.bar.classList.add('bg-ink');
     }
 
-    let left = _stateLabel(st);
-    if (st === 'running' && phase === 'validate') left = '正在预处理…';
-    if (st === 'paused' && phase === 'process') left = (done > 0 ? '校对已暂停' : '预处理完成，等待开始校对');
-    if (st === 'running' && phase === 'process') left = '正在校对…';
-    if (st === 'error' && phase === 'process') left = '校对出错';
-    if (st === 'paused' && phase === 'merge') left = '校对完成，等待合并输出';
-    if (st === 'running' && phase === 'merge') left = '正在合并输出…';
-    if (st === 'done') left = '完成';
+    let left = _snapshotLabel(job);
+    if (execution === 'queued' && phase === 'validate') left = '预处理排队中…';
+    if (execution === 'running' && phase === 'validate') left = '正在预处理…';
+    if (wait === 'ready_to_process') left = '预处理完成，等待开始校对';
+    if (wait === 'user_paused') left = '校对已暂停';
+    if (execution === 'queued' && phase === 'process') left = '校对排队中…';
+    if (execution === 'running' && phase === 'process') left = '正在校对…';
+    if (terminal === 'error' && phase === 'process') left = '校对出错';
+    if (wait === 'ready_to_merge') left = '校对完成，等待合并输出';
+    if (wait === 'server_recovered') left = '服务重启后等待继续';
+    if (execution === 'queued' && phase === 'merge') left = '合并排队中…';
+    if (execution === 'running' && phase === 'merge') left = '正在合并输出…';
+    if (terminal === 'done') left = '完成';
 
     if (elements.metaLeft) elements.metaLeft.textContent = left;
     if (elements.metaCounter) elements.metaCounter.textContent = `${done}/${total}`;
@@ -412,7 +440,7 @@ const LLM_FIELDS = [
 
 export function refreshLocks(job) {
     const hasJob = !!job;
-    const llmLocked = hasJob && ['queued', 'running'].includes(String(job.state || ''));
+    const llmLocked = hasJob && ['queued', 'running'].includes(String(job.execution_state || ''));
 
     _setFieldsDisabled(SLICE_FIELDS, hasJob);
     if (elements.sliceLockHint) {
@@ -428,8 +456,10 @@ export function refreshLocks(job) {
 }
 
 export function refreshWorkflowStepper(job) {
-    const st = String(job?.state || '').toLowerCase();
-    const phase = String(job?.phase || '').toLowerCase();
+    const execution = String(job?.execution_state || '').toLowerCase();
+    const phase = String(job?.workflow_phase || '').toLowerCase();
+    const terminal = job?.terminal_state == null ? null : String(job.terminal_state).toLowerCase();
+    const wait = job?.wait_reason == null ? null : String(job.wait_reason).toLowerCase();
     const hasJob = !!job;
 
     const order = ['validate', 'process', 'merge', 'done'];
@@ -438,7 +468,7 @@ export function refreshWorkflowStepper(job) {
 
     let cur = hasJob ? phase : 'validate';
     if (!order.includes(cur)) cur = 'validate';
-    if (st === 'done') cur = 'done';
+    if (terminal === 'done') cur = 'done';
     const curIdx = order.indexOf(cur);
 
     elements.wfNodes.forEach((node) => {
@@ -446,7 +476,7 @@ export function refreshWorkflowStepper(job) {
         const idx = order.indexOf(step);
         const isDone = idx >= 0 && idx < curIdx;
         const isActive = idx === curIdx;
-        const isError = isActive && hasJob && st === 'error';
+        const isError = isActive && hasJob && terminal === 'error';
 
         const dot = node.querySelector('.wf-dot');
         const label = node.querySelector('.wf-label');
@@ -486,10 +516,12 @@ export function refreshWorkflowStepper(job) {
         let badgeText = '未开始';
         let badgeCls = 'text-xs text-slate-400';
         if (hasJob) {
-            badgeText = _stateLabel(st);
-            if (st === 'paused') badgeCls = 'text-xs text-amber-600';
-            else if (st === 'error') badgeCls = 'text-xs text-red-600';
-            else if (st === 'done') badgeCls = 'text-xs text-emerald-600';
+            badgeText = _snapshotLabel(job);
+            if (wait) badgeCls = 'text-xs text-amber-600';
+            else if (terminal === 'error') badgeCls = 'text-xs text-red-600';
+            else if (terminal === 'done') badgeCls = 'text-xs text-emerald-600';
+            else if (terminal === 'cancelled') badgeCls = 'text-xs text-slate-600';
+            else if (execution === 'queued' || execution === 'running') badgeCls = 'text-xs text-slate-500';
             else badgeCls = 'text-xs text-slate-500';
         }
         elements.wfStateBadge.textContent = badgeText;
@@ -527,13 +559,13 @@ export function refreshActionButtons(job) {
     }
 
     if (elements.btnProcess) {
-        elements.btnProcess.textContent = (actions.hasJob && actions.phase === 'process' && actions.doneChunks > 0)
+        elements.btnProcess.textContent = (actions.hasJob && actions.workflowPhase === 'process' && actions.doneChunks > 0)
             ? '继续校对'
             : '开始校对';
     }
 
     if (elements.btnCancel) elements.btnCancel.textContent = '新任务';
-    if (elements.btnReset) elements.btnReset.textContent = (actions.hasJob && actions.state === 'done') ? '删除任务记录' : '删除任务';
+    if (elements.btnReset) elements.btnReset.textContent = (actions.hasJob && actions.terminalState === 'done') ? '删除任务记录' : '删除任务';
 
     const primaryKey = primaryActionKey(job, {
         hasLocalFile,

--- a/templates/static/js/workflow.js
+++ b/templates/static/js/workflow.js
@@ -1,22 +1,26 @@
 // Workflow state helpers shared by UI rendering and event handlers.
 
 export function normalizeJobState(job) {
+    const commands = Array.isArray(job?.available_commands) ? job.available_commands.map((v) => String(v)) : [];
     return {
         hasJob: !!job?.id,
-        state: String(job?.state || '').toLowerCase(),
-        phase: String(job?.phase || '').toLowerCase(),
+        workflowPhase: String(job?.workflow_phase || '').toLowerCase(),
+        executionState: String(job?.execution_state || '').toLowerCase(),
+        waitReason: job?.wait_reason == null ? null : String(job.wait_reason).toLowerCase(),
+        terminalState: job?.terminal_state == null ? null : String(job.terminal_state).toLowerCase(),
+        commands: new Set(commands),
         doneChunks: Number(job?.progress?.done_chunks || 0),
     };
 }
 
-export function isInFlight(stateName) {
-    return stateName === 'queued' || stateName === 'running';
+export function isInFlight(executionState) {
+    return executionState === 'queued' || executionState === 'running';
 }
 
 export function actionAvailability(job, { hasLocalFile = false, createJobInFlight = false } = {}) {
     const view = normalizeJobState(job);
-    const inFlight = isInFlight(view.state);
-    const canResumeValidate = view.hasJob && view.state === 'paused' && view.phase === 'validate';
+    const inFlight = isInFlight(view.executionState);
+    const canResumeValidate = view.hasJob && view.commands.has('validate');
     const canStartValidate = !view.hasJob && !!hasLocalFile && !createJobInFlight;
 
     return {
@@ -26,13 +30,13 @@ export function actionAvailability(job, { hasLocalFile = false, createJobInFligh
         canStartValidate,
         canValidate: canResumeValidate || canStartValidate,
         isSubmitting: !view.hasJob && !!createJobInFlight,
-        canProcess: view.hasJob && view.state === 'paused' && view.phase === 'process',
-        canMerge: view.hasJob && view.state === 'paused' && view.phase === 'merge',
-        canPause: view.hasJob && inFlight && view.phase === 'process',
-        canRetry: view.hasJob && view.state === 'error',
-        canDetach: view.hasJob && !inFlight,
-        canHardReset: view.hasJob && !(inFlight && view.phase === 'process'),
-        canDownload: view.hasJob && view.state === 'done',
+        canProcess: view.hasJob && view.commands.has('process'),
+        canMerge: view.hasJob && view.commands.has('merge'),
+        canPause: view.hasJob && view.commands.has('pause'),
+        canRetry: view.hasJob && view.commands.has('retry_failed'),
+        canDetach: view.hasJob && view.commands.has('detach'),
+        canHardReset: view.hasJob && view.commands.has('reset') && !(inFlight && view.workflowPhase === 'process'),
+        canDownload: view.hasJob && view.commands.has('download'),
     };
 }
 

--- a/templates/static/js/workflow.js
+++ b/templates/static/js/workflow.js
@@ -17,6 +17,38 @@ export function isInFlight(executionState) {
     return executionState === 'queued' || executionState === 'running';
 }
 
+export function snapshotLabel(job) {
+    const view = normalizeJobState(job);
+    if (!view.hasJob) return '-';
+
+    if (view.terminalState) {
+        const labels = { done: '已完成', error: '出错', cancelled: '已删除' };
+        return labels[view.terminalState] || `未知终态:${view.terminalState}`;
+    }
+    if (view.executionState === 'queued') return '排队中';
+    if (view.executionState === 'running') return '运行中';
+    if (view.executionState !== 'idle') return `未知执行态:${view.executionState || '-'}`;
+    if (!view.waitReason) return '空闲';
+
+    const waitLabels = {
+        ready_to_process: '等待开始校对',
+        user_paused: '已暂停',
+        ready_to_merge: '等待合并输出',
+        server_recovered: '服务重启后等待继续',
+    };
+    return waitLabels[view.waitReason] || `未知等待原因:${view.waitReason}`;
+}
+
+export function snapshotTone(job) {
+    const view = normalizeJobState(job);
+    if (!view.hasJob) return 'neutral';
+    if (view.waitReason) return 'wait';
+    if (view.terminalState === 'error') return 'error';
+    if (view.terminalState === 'done') return 'success';
+    if (view.executionState === 'queued' || view.executionState === 'running') return 'active';
+    return 'neutral';
+}
+
 export function actionAvailability(job, { hasLocalFile = false, createJobInFlight = false } = {}) {
     const view = normalizeJobState(job);
     const inFlight = isInFlight(view.executionState);

--- a/tests/api/test_endpoints.py
+++ b/tests/api/test_endpoints.py
@@ -23,11 +23,31 @@ def _wait_job_done(client: TestClient, job_id: str, *, timeout_seconds: float = 
         res = client.get(f"/api/v1/jobs/{job_id}?chunks=0")
         assert res.status_code == 200
         last = res.json()
-        state = (last.get("job") or {}).get("state")
-        if state in {"done", "error", "cancelled", "paused"}:
+        job = last.get("job") or {}
+        if job.get("terminal_state") in {"done", "error", "cancelled"} or job.get("wait_reason"):
             return last
         time.sleep(0.05)
     raise AssertionError(f"job did not finish in time; last={last}")
+
+
+def _assert_snapshot(
+    body: dict,
+    *,
+    workflow_phase: str,
+    execution_state: str = "idle",
+    wait_reason: str | None = None,
+    terminal_state: str | None = None,
+    commands: set[str] | None = None,
+) -> None:
+    job = body.get("job") or {}
+    assert "state" not in job
+    assert "phase" not in job
+    assert job.get("workflow_phase") == workflow_phase
+    assert job.get("execution_state") == execution_state
+    assert job.get("wait_reason") == wait_reason
+    assert job.get("terminal_state") == terminal_state
+    if commands is not None:
+        assert set(job.get("available_commands") or []) == commands
 
 
 def test_healthz_ok():
@@ -80,8 +100,12 @@ def test_create_job_local_mode_writes_output_and_is_queryable(monkeypatch: pytes
         try:
             # Phase 1: validate (ends paused, ready to process)
             st1 = _wait_job_done(client, job_id, timeout_seconds=5.0)
-            assert (st1.get("job") or {}).get("state") == "paused"
-            assert (st1.get("job") or {}).get("phase") == "process"
+            _assert_snapshot(
+                st1,
+                workflow_phase="process",
+                wait_reason="ready_to_process",
+                commands={"process", "detach", "reset"},
+            )
 
             # Phase 2: process (ends paused, ready to merge)
             r2 = client.post(
@@ -90,15 +114,23 @@ def test_create_job_local_mode_writes_output_and_is_queryable(monkeypatch: pytes
             )
             assert r2.status_code == 200, r2.text
             st2 = _wait_job_done(client, job_id, timeout_seconds=10.0)
-            assert (st2.get("job") or {}).get("state") == "paused"
-            assert (st2.get("job") or {}).get("phase") == "merge"
+            _assert_snapshot(
+                st2,
+                workflow_phase="merge",
+                wait_reason="ready_to_merge",
+                commands={"merge", "detach", "reset"},
+            )
 
             # Phase 3: merge (ends done, output exists)
             r3 = client.post(f"/api/v1/jobs/{job_id}/merge", json={"cleanup_debug_dir": True})
             assert r3.status_code == 200, r3.text
             final = _wait_job_done(client, job_id, timeout_seconds=5.0)
-            assert (final.get("job") or {}).get("state") == "done"
-            assert (final.get("job") or {}).get("phase") == "done"
+            _assert_snapshot(
+                final,
+                workflow_phase="done",
+                terminal_state="done",
+                commands={"detach", "reset", "download"},
+            )
 
             output_filename = (final.get("job") or {}).get("output_filename")
             assert isinstance(output_filename, str) and output_filename
@@ -157,20 +189,18 @@ def test_get_job_chunk_filter_and_paging(monkeypatch: pytest.MonkeyPatch):
 
         try:
             st1 = _wait_job_done(client, job_id, timeout_seconds=10.0)
-            assert (st1.get("job") or {}).get("state") == "paused"
-            assert (st1.get("job") or {}).get("phase") == "process"
+            _assert_snapshot(st1, workflow_phase="process", wait_reason="ready_to_process")
 
             client.post(
                 f"/api/v1/jobs/{job_id}/resume",
                 json={"llm": {"base_url": "http://example.com", "model": "m", "max_concurrency": 1}},
             )
             st2 = _wait_job_done(client, job_id, timeout_seconds=10.0)
-            assert (st2.get("job") or {}).get("state") == "paused"
-            assert (st2.get("job") or {}).get("phase") == "merge"
+            _assert_snapshot(st2, workflow_phase="merge", wait_reason="ready_to_merge")
 
             client.post(f"/api/v1/jobs/{job_id}/merge", json={"cleanup_debug_dir": True})
             final = _wait_job_done(client, job_id, timeout_seconds=10.0)
-            assert (final.get("job") or {}).get("state") == "done"
+            _assert_snapshot(final, workflow_phase="done", terminal_state="done")
 
             r2 = client.get(f"/api/v1/jobs/{job_id}?chunks=1&chunk_state=done&limit=1&offset=0")
             assert r2.status_code == 200
@@ -262,13 +292,14 @@ def test_create_job_llm_enabled_requires_base_url_and_model(monkeypatch: pytest.
         try:
             # Validate succeeds without LLM config.
             st1 = _wait_job_done(client, job_id, timeout_seconds=5.0)
-            assert (st1.get("job") or {}).get("state") == "paused"
-            assert (st1.get("job") or {}).get("phase") == "process"
+            _assert_snapshot(st1, workflow_phase="process", wait_reason="ready_to_process")
 
             # Processing requires base_url/model and should fail when empty.
             client.post(f"/api/v1/jobs/{job_id}/resume", json={"llm": {"base_url": "", "model": ""}})
             st2 = _wait_job_done(client, job_id, timeout_seconds=5.0)
-            assert (st2.get("job") or {}).get("state") == "error"
+            _assert_snapshot(
+                st2, workflow_phase="process", terminal_state="error", commands={"retry_failed", "detach", "reset"}
+            )
         finally:
             GLOBAL_JOBS.delete(str(job_id))
 
@@ -297,6 +328,56 @@ def test_job_actions_pause_resume(monkeypatch: pytest.MonkeyPatch):
         assert st2 is not None and st2.state in {"queued", "running"}
     finally:
         GLOBAL_JOBS.delete(job2.job_id)
+
+
+def test_job_snapshot_contract_covers_running_user_paused_and_cancelled() -> None:
+    client = TestClient(api.app)
+    job = GLOBAL_JOBS.create("in.txt", "out.txt", total_chunks=0)
+    try:
+        GLOBAL_JOBS.update(job.job_id, state="running", phase="process")
+
+        running = client.get(f"/api/v1/jobs/{job.job_id}?chunks=0")
+        assert running.status_code == 200, running.text
+        _assert_snapshot(
+            running.json(),
+            workflow_phase="process",
+            execution_state="running",
+            commands={"pause", "reset"},
+        )
+
+        paused = client.post(f"/api/v1/jobs/{job.job_id}/pause")
+        assert paused.status_code == 200, paused.text
+        _assert_snapshot(
+            paused.json(),
+            workflow_phase="process",
+            wait_reason="user_paused",
+            commands={"process", "detach", "reset"},
+        )
+
+        GLOBAL_JOBS.resume(job.job_id)
+        GLOBAL_JOBS.cancel(job.job_id)
+        cancelled = client.get(f"/api/v1/jobs/{job.job_id}?chunks=0")
+        assert cancelled.status_code == 200, cancelled.text
+        _assert_snapshot(cancelled.json(), workflow_phase="process", terminal_state="cancelled", commands=set())
+    finally:
+        GLOBAL_JOBS.delete(job.job_id)
+
+
+def test_job_list_uses_snapshot_contract_without_legacy_state_fields() -> None:
+    client = TestClient(api.app)
+    job = GLOBAL_JOBS.create("in.txt", "out.txt", total_chunks=0)
+    try:
+        r = client.get("/api/v1/jobs")
+        assert r.status_code == 200, r.text
+        item = next(j for j in (r.json().get("jobs") or []) if j.get("id") == job.job_id)
+        assert "state" not in item
+        assert "phase" not in item
+        assert item.get("workflow_phase") == "validate"
+        assert item.get("execution_state") == "queued"
+        assert item.get("wait_reason") is None
+        assert item.get("terminal_state") is None
+    finally:
+        GLOBAL_JOBS.delete(job.job_id)
 
 
 def test_job_input_stats_endpoint(monkeypatch: pytest.MonkeyPatch):
@@ -544,8 +625,7 @@ def test_rerun_all_creates_new_job_without_reupload(monkeypatch: pytest.MonkeyPa
 
         try:
             st1 = _wait_job_done(client, job_id, timeout_seconds=5.0)
-            assert (st1.get("job") or {}).get("state") == "paused"
-            assert (st1.get("job") or {}).get("phase") == "process"
+            _assert_snapshot(st1, workflow_phase="process", wait_reason="ready_to_process")
 
             input_cache = out_dir / ".inputs" / f"{job_id}.txt"
             assert input_cache.exists()
@@ -556,8 +636,7 @@ def test_rerun_all_creates_new_job_without_reupload(monkeypatch: pytest.MonkeyPa
             assert isinstance(job_id2, str) and len(job_id2) == 32 and job_id2 != job_id
 
             st2 = _wait_job_done(client, job_id2, timeout_seconds=5.0)
-            assert (st2.get("job") or {}).get("state") == "paused"
-            assert (st2.get("job") or {}).get("phase") == "process"
+            _assert_snapshot(st2, workflow_phase="process", wait_reason="ready_to_process")
 
             # Process + merge rerun job to ensure output path is produced.
             client.post(
@@ -565,12 +644,11 @@ def test_rerun_all_creates_new_job_without_reupload(monkeypatch: pytest.MonkeyPa
                 json={"llm": {"base_url": "http://example.com", "model": "m", "max_concurrency": 1}},
             )
             st3 = _wait_job_done(client, job_id2, timeout_seconds=5.0)
-            assert (st3.get("job") or {}).get("state") == "paused"
-            assert (st3.get("job") or {}).get("phase") == "merge"
+            _assert_snapshot(st3, workflow_phase="merge", wait_reason="ready_to_merge")
 
             client.post(f"/api/v1/jobs/{job_id2}/merge", json={"cleanup_debug_dir": True})
             final2 = _wait_job_done(client, job_id2, timeout_seconds=5.0)
-            assert (final2.get("job") or {}).get("state") == "done"
+            _assert_snapshot(final2, workflow_phase="done", terminal_state="done")
             assert (out_dir / (final2.get("job") or {}).get("output_filename")).exists()
         finally:
             GLOBAL_JOBS.delete(str(job_id))

--- a/tests/api/test_workflow_js.py
+++ b/tests/api/test_workflow_js.py
@@ -1,0 +1,85 @@
+from __future__ import annotations
+
+import subprocess
+import textwrap
+
+
+def test_frontend_workflow_actions_use_snapshot_commands() -> None:
+    script = textwrap.dedent(
+        """
+        import assert from 'node:assert/strict';
+        import { actionAvailability, primaryActionKey } from './templates/static/js/workflow.js';
+
+        const readyToProcess = {
+            id: 'job1',
+            workflow_phase: 'process',
+            execution_state: 'idle',
+            wait_reason: 'ready_to_process',
+            terminal_state: null,
+            available_commands: ['process', 'detach', 'reset'],
+            progress: { done_chunks: 0, total_chunks: 1 },
+        };
+        assert.equal(actionAvailability(readyToProcess).canProcess, true);
+        assert.equal(primaryActionKey(readyToProcess), 'process');
+
+        const userPaused = {
+            ...readyToProcess,
+            wait_reason: 'user_paused',
+            progress: { done_chunks: 1, total_chunks: 3 },
+        };
+        assert.equal(actionAvailability(userPaused).canProcess, true);
+        assert.equal(actionAvailability(userPaused).canPause, false);
+
+        const running = {
+            id: 'job2',
+            workflow_phase: 'process',
+            execution_state: 'running',
+            wait_reason: null,
+            terminal_state: null,
+            available_commands: ['pause', 'reset'],
+            progress: { done_chunks: 1, total_chunks: 3 },
+        };
+        assert.equal(actionAvailability(running).canPause, true);
+        assert.equal(actionAvailability(running).canProcess, false);
+        assert.equal(actionAvailability(running).canHardReset, false);
+        assert.equal(primaryActionKey(running), 'pause');
+
+        const readyToMerge = {
+            id: 'job3',
+            workflow_phase: 'merge',
+            execution_state: 'idle',
+            wait_reason: 'ready_to_merge',
+            terminal_state: null,
+            available_commands: ['merge', 'detach', 'reset'],
+            progress: { done_chunks: 3, total_chunks: 3 },
+        };
+        assert.equal(actionAvailability(readyToMerge).canMerge, true);
+        assert.equal(primaryActionKey(readyToMerge), 'merge');
+
+        const done = {
+            id: 'job4',
+            workflow_phase: 'done',
+            execution_state: 'idle',
+            wait_reason: null,
+            terminal_state: 'done',
+            available_commands: ['download', 'detach', 'reset'],
+            progress: { done_chunks: 3, total_chunks: 3 },
+        };
+        assert.equal(actionAvailability(done).canDownload, true);
+        assert.equal(primaryActionKey(done), 'download');
+
+        const cancelled = {
+            id: 'job5',
+            workflow_phase: 'process',
+            execution_state: 'idle',
+            wait_reason: null,
+            terminal_state: 'cancelled',
+            available_commands: [],
+            progress: { done_chunks: 0, total_chunks: 3 },
+        };
+        assert.equal(actionAvailability(cancelled).canDetach, false);
+        assert.equal(primaryActionKey(cancelled), null);
+        """
+    )
+
+    subprocess.run(["node", "--input-type=module", "-e", script], check=True)

--- a/tests/api/test_workflow_js.py
+++ b/tests/api/test_workflow_js.py
@@ -8,7 +8,7 @@ def test_frontend_workflow_actions_use_snapshot_commands() -> None:
     script = textwrap.dedent(
         """
         import assert from 'node:assert/strict';
-        import { actionAvailability, primaryActionKey } from './templates/static/js/workflow.js';
+        import { actionAvailability, primaryActionKey, snapshotLabel, snapshotTone } from './templates/static/js/workflow.js';
 
         const readyToProcess = {
             id: 'job1',
@@ -29,6 +29,8 @@ def test_frontend_workflow_actions_use_snapshot_commands() -> None:
         };
         assert.equal(actionAvailability(userPaused).canProcess, true);
         assert.equal(actionAvailability(userPaused).canPause, false);
+        assert.equal(snapshotLabel(userPaused), '已暂停');
+        assert.equal(snapshotTone(userPaused), 'wait');
 
         const running = {
             id: 'job2',
@@ -67,6 +69,8 @@ def test_frontend_workflow_actions_use_snapshot_commands() -> None:
         };
         assert.equal(actionAvailability(done).canDownload, true);
         assert.equal(primaryActionKey(done), 'download');
+        assert.equal(snapshotLabel(done), '已完成');
+        assert.equal(snapshotTone(done), 'success');
 
         const cancelled = {
             id: 'job5',

--- a/tests/jobs/test_store.py
+++ b/tests/jobs/test_store.py
@@ -8,7 +8,7 @@ import pytest
 
 from novel_proofer.formatting.config import FormatConfig
 from novel_proofer.jobs import JobStore, _job_from_dict
-from novel_proofer.states import ChunkState, JobPhase, JobState
+from novel_proofer.states import ChunkState, JobPhase, JobState, WaitReason
 
 
 def test_job_store_update_respects_started_at_and_pause_rules() -> None:
@@ -23,6 +23,9 @@ def test_job_store_update_respects_started_at_and_pause_rules() -> None:
     assert st.started_at == 123.0
 
     assert js.pause(job_id) is True
+    paused = js.get(job_id)
+    assert paused is not None
+    assert paused.wait_reason == WaitReason.USER_PAUSED
     # update() should not move paused -> running/queued.
     js.update(job_id, state="running")
     st2 = js.get(job_id)
@@ -144,6 +147,9 @@ def test_job_store_pause_resume_and_delete() -> None:
 
     assert js.resume(job_id) is True
     assert js.is_paused(job_id) is False
+    resumed = js.get(job_id)
+    assert resumed is not None
+    assert resumed.wait_reason is None
 
     assert js.delete(job_id) is True
     assert js.delete(job_id) is False
@@ -209,10 +215,11 @@ def test_job_store_persistence_is_throttled_and_flushable(tmp_path: Path) -> Non
 
 def test_job_from_dict_rejects_missing_phase() -> None:
     raw = {
-        "version": 2,
+        "version": 3,
         "job": {
             "job_id": "a" * 32,
             "state": "paused",
+            "wait_reason": WaitReason.USER_PAUSED,
             "created_at": 1.0,
             "started_at": None,
             "finished_at": None,
@@ -249,11 +256,12 @@ def test_job_store_load_persisted_jobs_rejects_corrupt_snapshot(tmp_path: Path) 
     bad.write_text(
         json.dumps(
             {
-                "version": 2,
+                "version": 3,
                 "job": {
                     "job_id": "a" * 32,
                     "state": JobState.PAUSED,
                     "phase": JobPhase.MERGE,
+                    "wait_reason": WaitReason.READY_TO_MERGE,
                     "created_at": 1.0,
                     "started_at": None,
                     "finished_at": None,
@@ -312,11 +320,12 @@ def test_job_store_load_persisted_jobs_restores_running_job_as_paused(tmp_path: 
     snap.write_text(
         json.dumps(
             {
-                "version": 2,
+                "version": 3,
                 "job": {
                     "job_id": "b" * 32,
                     "state": JobState.RUNNING,
                     "phase": JobPhase.PROCESS,
+                    "wait_reason": None,
                     "created_at": 1.0,
                     "started_at": 2.0,
                     "finished_at": None,
@@ -368,6 +377,7 @@ def test_job_store_load_persisted_jobs_restores_running_job_as_paused(tmp_path: 
         assert loaded is not None
         assert loaded.state == JobState.PAUSED
         assert loaded.phase == JobPhase.PROCESS
+        assert loaded.wait_reason == WaitReason.SERVER_RECOVERED
         assert loaded.chunk_statuses[0].state == ChunkState.PENDING
         assert loaded.chunk_statuses[0].started_at is None
     finally:

--- a/tests/jobs/test_store.py
+++ b/tests/jobs/test_store.py
@@ -3,12 +3,54 @@ from __future__ import annotations
 import json
 import time
 from pathlib import Path
+from typing import Any
 
 import pytest
 
 from novel_proofer.formatting.config import FormatConfig
 from novel_proofer.jobs import JobStore, _job_from_dict
 from novel_proofer.states import ChunkState, JobPhase, JobState, WaitReason
+
+
+def _raw_job_snapshot(
+    *,
+    state: JobState | str = JobState.PAUSED,
+    phase: JobPhase | str = JobPhase.PROCESS,
+    wait_reason: WaitReason | str | None = WaitReason.USER_PAUSED,
+) -> dict[str, Any]:
+    return {
+        "version": 3,
+        "job": {
+            "job_id": "a" * 32,
+            "state": state,
+            "phase": phase,
+            "wait_reason": wait_reason,
+            "created_at": 1.0,
+            "started_at": None,
+            "finished_at": None,
+            "input_filename": "in.txt",
+            "output_filename": "out.txt",
+            "total_chunks": 0,
+            "done_chunks": 0,
+            "format": json.loads(json.dumps(FormatConfig().__dict__)),
+            "last_error_code": None,
+            "last_retry_count": 0,
+            "last_llm_model": None,
+            "stats": {},
+            "chunk_statuses": [],
+            "chunk_counts": {
+                "pending": 0,
+                "processing": 0,
+                "retrying": 0,
+                "done": 0,
+                "error": 0,
+            },
+            "error": None,
+            "output_path": None,
+            "work_dir": None,
+            "cleanup_debug_dir": True,
+        },
+    }
 
 
 def test_job_store_update_respects_started_at_and_pause_rules() -> None:
@@ -31,6 +73,10 @@ def test_job_store_update_respects_started_at_and_pause_rules() -> None:
     st2 = js.get(job_id)
     assert st2 is not None
     assert st2.state == "paused"
+    assert st2.wait_reason == WaitReason.USER_PAUSED
+
+    with pytest.raises(ValueError, match="wait_reason must be one of"):
+        js.update(job_id, wait_reason="bogus")
 
     # Marking terminal state should clear paused flag.
     js.update(job_id, state="done", finished_at=time.time())
@@ -214,40 +260,24 @@ def test_job_store_persistence_is_throttled_and_flushable(tmp_path: Path) -> Non
 
 
 def test_job_from_dict_rejects_missing_phase() -> None:
-    raw = {
-        "version": 3,
-        "job": {
-            "job_id": "a" * 32,
-            "state": "paused",
-            "wait_reason": WaitReason.USER_PAUSED,
-            "created_at": 1.0,
-            "started_at": None,
-            "finished_at": None,
-            "input_filename": "in.txt",
-            "output_filename": "out.txt",
-            "total_chunks": 0,
-            "done_chunks": 0,
-            "format": json.loads(json.dumps(FormatConfig().__dict__)),
-            "last_error_code": None,
-            "last_retry_count": 0,
-            "last_llm_model": None,
-            "stats": {},
-            "chunk_statuses": [],
-            "chunk_counts": {
-                "pending": 0,
-                "processing": 0,
-                "retrying": 0,
-                "done": 0,
-                "error": 0,
-            },
-            "error": None,
-            "output_path": None,
-            "work_dir": None,
-            "cleanup_debug_dir": True,
-        },
-    }
+    raw = _raw_job_snapshot()
+    del raw["job"]["phase"]
 
     with pytest.raises(ValueError, match="missing field 'phase'"):
+        _job_from_dict(raw)
+
+
+def test_job_from_dict_rejects_paused_without_wait_reason() -> None:
+    raw = _raw_job_snapshot(wait_reason=None)
+
+    with pytest.raises(ValueError, match="wait_reason is required"):
+        _job_from_dict(raw)
+
+
+def test_job_from_dict_rejects_non_paused_with_wait_reason() -> None:
+    raw = _raw_job_snapshot(state=JobState.RUNNING, phase=JobPhase.VALIDATE, wait_reason=WaitReason.USER_PAUSED)
+
+    with pytest.raises(ValueError, match="wait_reason must be null"):
         _job_from_dict(raw)
 
 

--- a/tests/runner/test_run_job.py
+++ b/tests/runner/test_run_job.py
@@ -78,6 +78,41 @@ def test_run_job_local_mode_cleans_up_by_default(monkeypatch: pytest.MonkeyPatch
             GLOBAL_JOBS.delete(job_id)
 
 
+def test_run_job_pause_after_chunk_initialization_stays_in_process_phase(monkeypatch: pytest.MonkeyPatch) -> None:
+    with tempfile.TemporaryDirectory() as td:
+        work_dir = Path(td) / "work"
+        out_path = Path(td) / "out.txt"
+        input_path = Path(td) / "in.txt"
+        input_path.write_text("第1章\r\n\r\n你好。\r\n", encoding="utf-8")
+
+        job = GLOBAL_JOBS.create("in.txt", "out.txt", total_chunks=0)
+        job_id = job.job_id
+        original_init_chunks = GLOBAL_JOBS.init_chunks
+
+        def pause_after_init_chunks(target_job_id: str, *args: object, **kwargs: object) -> None:
+            original_init_chunks(target_job_id, *args, **kwargs)
+            assert GLOBAL_JOBS.pause(target_job_id) is True
+
+        monkeypatch.setattr(GLOBAL_JOBS, "init_chunks", pause_after_init_chunks)
+        try:
+            GLOBAL_JOBS.update(job_id, work_dir=str(work_dir), output_path=str(out_path))
+
+            runner.run_job(
+                job_id,
+                input_path,
+                FormatConfig(max_chunk_chars=2000),
+                LLMConfig(base_url="http://example.com", model="m", max_concurrency=1),
+            )
+
+            st = GLOBAL_JOBS.get(job_id)
+            assert st is not None
+            assert st.state == "paused"
+            assert st.phase == "process"
+            assert st.wait_reason == "user_paused"
+        finally:
+            GLOBAL_JOBS.delete(job_id)
+
+
 def test_run_job_local_mode_keeps_debug_dir_when_opted_out(monkeypatch: pytest.MonkeyPatch) -> None:
     monkeypatch.setattr(
         runner,


### PR DESCRIPTION
## Summary
- replace the public job `state`/`phase` response contract with `workflow_phase`, `execution_state`, `wait_reason`, `terminal_state`, and `available_commands`
- enforce explicit `wait_reason` invariants for paused jobs and restore previously active jobs as `server_recovered`
- move API list/detail conversion, frontend action availability, OpenAPI schema, docs, and tests onto the snapshot contract

Closes #76

## Validation
- `uv run --frozen --no-sync ruff format --check`
- `uv run --frozen --no-sync ruff check`
- `uv run --frozen --no-sync python -m mypy novel_proofer`
- `uv run --frozen --no-sync python tools/export-openapi.py --check`
- `uv run --frozen --no-sync python tools/check-large-files.py`
- `uv run --frozen --no-sync python -m pytest -q -m "not llm_integration"` -> 144 passed, 5 deselected

## Known Test Gap
- Full `python -m pytest -q` still fails only in the live `llm_integration` corpus cases because the external LLM run reports chunk failures; this is outside the snapshot contract refactor.

## Summary by Sourcery

Refine the public job workflow API to expose a new snapshot-based contract and update backend, persistence, and frontend consumers accordingly.

New Features:
- Expose workflow-oriented job snapshot fields (workflow_phase, execution_state, wait_reason, terminal_state, available_commands) in job detail and list APIs for UI consumption.

Enhancements:
- Introduce derivation of snapshot fields and available job commands from internal job state and phase, and enforce explicit wait_reason invariants for paused jobs including recovery after restart.
- Adjust job runner and store logic to set, validate, and clear wait_reason consistently across pause, resume, cancel, retry, and restart flows.
- Refactor frontend workflow logic, progress display, action availability, and job picker to consume the new snapshot contract instead of internal state/phase fields.
- Clarify architecture and state machine documentation to describe the new snapshot-based API surface and separation from internal job state.

Documentation:
- Update workflow recovery and state machine docs to document the snapshot contract fields and their semantics.

Tests:
- Extend and update API, job store, and frontend workflow tests to cover the new snapshot contract, wait_reason invariants, and command-driven action availability.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 发布说明

* **API 变更**
  * 重构了作业状态字段组合：用 `workflow_phase`、`execution_state`、`wait_reason`、`terminal_state` 和 `available_commands` 替代原有的 `state` 和 `phase` 字段，提供更细粒度的工作流状态信息。

* **UI/UX 改进**
  * 前端界面现基于可用命令列表和新的状态字段更准确地呈现工作流进度和操作选项。

* **文档**
  * 更新 API 文档和架构文档以反映新的状态字段契约。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->