### PR TITLE
refactor(workflow): centralize transition rules

### DIFF
--- a/docs/TESTCASES.md
+++ b/docs/TESTCASES.md
@@ -20,6 +20,7 @@
 | `tests/api/test_endpoints.py::test_job_actions_pause_resume` | 覆盖任务动作接口：`pause/resume` 的返回值与状态流转（通过 monkeypatch 避免真实 runner 副作用）。 |
 | `tests/api/test_endpoints.py::test_pause_only_allowed_in_process_phase` | `pause` 仅允许在 `phase=process` 时执行；其他阶段返回 `409`。 |
 | `tests/api/test_endpoints.py::test_reset_job_deletes_job` | 覆盖 `reset`：任务会从任务列表中被删除（但不会删除 `output/` 下已生成的最终输出）。 |
+| `tests/api/test_endpoints.py::test_reset_completed_job_deletes_without_forcing_cancel` | 覆盖完成态 `reset`：按 workflow decision 直接清理删除，不额外写入 `cancelled` 状态。 |
 | `tests/api/test_endpoints.py::test_llm_settings_get_put_preserves_unknown_lines` | 覆盖 LLM 默认配置接口：`GET/PUT /api/v1/settings/llm`；验证写入 `.env` 时保留未知键/注释，并能读回保存的 LLM 字段。 |
 | `tests/api/test_endpoints.py::test_rerun_all_creates_new_job_without_reupload` | 覆盖 `POST /api/v1/jobs/{job_id}/rerun-all`：基于输入缓存创建新任务并从头跑完整流程，且不需要重新上传文件。 |
 | `tests/api/test_endpoints.py::test_job_input_stats_endpoint` | 覆盖 `GET /api/v1/jobs/{job_id}/input-stats`：基于输入缓存统计“非空白字符数”（UI 字数口径）。 |
@@ -57,6 +58,7 @@
 | Test case | 说明 |
 | --- | --- |
 | `tests/jobs/test_store.py::test_job_store_update_respects_started_at_and_pause_rules` | `started_at` 只接受首次写入；暂停状态不应被 `update(state="running")` 覆盖；进入终态（`done`）后清除 paused 标记。 |
+| `tests/jobs/test_store.py::test_job_store_update_rejects_invalid_workflow_combinations` | `JobStore.update()` 会拒绝非法 state/phase/wait_reason 组合，错误由 workflow invariant 统一给出。 |
 | `tests/jobs/test_store.py::test_job_store_update_chunk_tracks_done_chunks` | `done_chunks` 随分片状态在 `done/pending` 间切换而增减；越界 index 更新应被忽略。 |
 | `tests/jobs/test_store.py::test_job_store_add_retry_updates_job_and_chunk` | `add_retry()` 同时更新 job 级与 chunk 级重试/错误信息；无效 index 仍应累加 job 级计数。 |
 | `tests/jobs/test_store.py::test_job_store_cancel_resets_processing_chunks` | 触发“删除任务（reset）”的终止信号后：任务变为 `cancelled` 且写入 `finished_at`，正在处理/重试的 chunk 重置为 `pending` 并清空时间戳。 |
@@ -73,14 +75,17 @@
 | `tests/test_workflow.py::test_retry_guard_requires_error_state_with_failed_chunks` | 兼容层校验 retry failed 只允许 error job 且存在失败分片。 |
 | `tests/test_workflow.py::test_processing_final_state_depends_only_on_chunk_states` | 校验处理阶段最终状态只由分片 error/done 汇总决定。 |
 | `tests/test_workflow.py::test_merge_guard_requires_paused_merge_phase_and_complete_chunks` | 兼容层校验 merge 只允许 paused + merge phase + 分片全 done。 |
-| `tests/test_workflow.py::test_persisted_phase_invariants_are_centralized` | 校验持久化 phase/state/chunk invariant 统一由 workflow 模块暴露。 |
+| `tests/test_workflow.py::test_persisted_phase_invariants_are_centralized` | 校验持久化 phase/state/chunk invariants 统一由 workflow 模块暴露。 |
 | `tests/test_workflow.py::test_command_decisions_return_explicit_next_state_and_target` | 表驱动校验合法命令返回明确 next workflow state 与 resume target。 |
 | `tests/test_workflow.py::test_illegal_commands_return_typed_rejections` | 表驱动校验非法命令返回 typed rejection code/message，而不是静默 no-op。 |
+| `tests/test_workflow.py::test_require_command_preserves_rejection_message_and_code` | 校验 exception 调用路径保留 command rejection 的 message 与 code。 |
 | `tests/test_workflow.py::test_workflow_events_are_table_driven` | 表驱动校验 validation/process/retry/merge/reset/restart 等事件转移。 |
 | `tests/test_workflow.py::test_illegal_events_return_typed_rejections` | 表驱动校验非法 workflow event 返回 typed rejection code/message。 |
+| `tests/test_workflow.py::test_require_event_preserves_rejection_message_and_code` | 校验 exception 调用路径保留 event rejection 的 message 与 code。 |
+| `tests/test_workflow.py::test_resume_decision_rejects_merge_and_done_without_process_fallthrough` | 校验 resume decision 不会把 merge/done phase 错误地落回 process command。 |
 | `tests/test_workflow.py::test_pause_is_legal_only_for_in_flight_process_phase` | 遍历所有 phase，校验 pause 只在运行中的 process phase 合法。 |
 | `tests/test_workflow.py::test_process_resume_allows_process_wait_reasons` | 遍历 process 可恢复 wait reason，校验 process command 合法性。 |
-| `tests/test_workflow.py::test_wait_reasons_are_phase_specific` | 校验 wait reason 与 phase 必须匹配，非法组合响亮失败。 |
+| `tests/test_workflow.py::test_wait_reasons_are_phase_specific` | 校验 wait reason 与 phase 必须匹配，非法组合会明确失败。 |
 | `tests/test_workflow.py::test_available_commands_are_derived_from_workflow_decisions` | 校验 UI/API 使用的 `available_commands` 来自 workflow command decision。 |
 | `tests/test_workflow.py::test_create_validation_state_is_the_only_new_job_workflow_entry` | 校验新 job 的唯一入口状态为 queued + validate。 |
 

--- a/docs/TESTCASES.md
+++ b/docs/TESTCASES.md
@@ -64,6 +64,26 @@
 | `tests/jobs/test_store.py::test_job_store_ignores_unknown_jobs_and_cancelled_updates` | 对未知 job 的操作应无副作用；对已标记为 `cancelled` 的 job 的 `update()/update_chunk()` 应 no-op，避免状态被“复活”。 |
 | `tests/jobs/test_store.py::test_job_store_persistence_is_throttled_and_flushable` | 持久化写盘不应发生在每次 `update_chunk()` 的热路径；dirty 更新应被节流并可通过 `flush_persistence()` 主动触发落盘。 |
 
+## tests/test_workflow.py
+
+| Test case | 说明 |
+| --- | --- |
+| `tests/test_workflow.py::test_pause_guard_is_process_only_and_in_flight_only` | 兼容层校验 pause 只允许在 `process` 阶段且执行中。 |
+| `tests/test_workflow.py::test_resume_guard_selects_validate_or_process_target` | 兼容层校验 resume 会按当前 phase 选择 `validate` 或 `process` 目标。 |
+| `tests/test_workflow.py::test_retry_guard_requires_error_state_with_failed_chunks` | 兼容层校验 retry failed 只允许 error job 且存在失败分片。 |
+| `tests/test_workflow.py::test_processing_final_state_depends_only_on_chunk_states` | 校验处理阶段最终状态只由分片 error/done 汇总决定。 |
+| `tests/test_workflow.py::test_merge_guard_requires_paused_merge_phase_and_complete_chunks` | 兼容层校验 merge 只允许 paused + merge phase + 分片全 done。 |
+| `tests/test_workflow.py::test_persisted_phase_invariants_are_centralized` | 校验持久化 phase/state/chunk invariant 统一由 workflow 模块暴露。 |
+| `tests/test_workflow.py::test_command_decisions_return_explicit_next_state_and_target` | 表驱动校验合法命令返回明确 next workflow state 与 resume target。 |
+| `tests/test_workflow.py::test_illegal_commands_return_typed_rejections` | 表驱动校验非法命令返回 typed rejection code/message，而不是静默 no-op。 |
+| `tests/test_workflow.py::test_workflow_events_are_table_driven` | 表驱动校验 validation/process/retry/merge/reset/restart 等事件转移。 |
+| `tests/test_workflow.py::test_illegal_events_return_typed_rejections` | 表驱动校验非法 workflow event 返回 typed rejection code/message。 |
+| `tests/test_workflow.py::test_pause_is_legal_only_for_in_flight_process_phase` | 遍历所有 phase，校验 pause 只在运行中的 process phase 合法。 |
+| `tests/test_workflow.py::test_process_resume_allows_process_wait_reasons` | 遍历 process 可恢复 wait reason，校验 process command 合法性。 |
+| `tests/test_workflow.py::test_wait_reasons_are_phase_specific` | 校验 wait reason 与 phase 必须匹配，非法组合响亮失败。 |
+| `tests/test_workflow.py::test_available_commands_are_derived_from_workflow_decisions` | 校验 UI/API 使用的 `available_commands` 来自 workflow command decision。 |
+| `tests/test_workflow.py::test_create_validation_state_is_the_only_new_job_workflow_entry` | 校验新 job 的唯一入口状态为 queued + validate。 |
+
 ## tests/llm/test_client.py
 
 | Test case | 说明 |

--- a/docs/TESTCASES.md
+++ b/docs/TESTCASES.md
@@ -171,6 +171,7 @@
 | Test case | 说明 |
 | --- | --- |
 | `tests/runner/test_run_job.py::test_run_job_missing_paths_sets_error` | `run_job()` 若 job 缺少 `work_dir/output_path` 必须置为 error 并提供错误信息。 |
+| `tests/runner/test_run_job.py::test_run_job_pause_during_validation_stays_in_validate_phase` | validation 分片前收到 pause 时，任务保持 `paused + validate + user_paused`，不会错误触发执行停止事件。 |
 | `tests/runner/test_run_job.py::test_run_job_local_mode_cleans_up_by_default` | 本地模式（LLM 关闭）默认在任务 done 后清理调试目录（`cleanup_debug_dir=True`）。 |
 | `tests/runner/test_run_job.py::test_run_job_local_mode_keeps_debug_dir_when_opted_out` | 显式关闭清理时应保留调试目录结构（`README.txt/pre/out`），且不应生成 `req/`、`error/` 目录。 |
 

--- a/novel_proofer/api.py
+++ b/novel_proofer/api.py
@@ -56,10 +56,33 @@ from novel_proofer.models import (
     RetryFailedRequest,
 )
 from novel_proofer.runner import merge_outputs, resume_paused_job, retry_failed_chunks, run_job
-from novel_proofer.states import ChunkState, JobPhase, JobState
-from novel_proofer.workflow import ResumeTarget, can_merge, can_pause, can_resume, can_retry_failed
+from novel_proofer.states import ChunkState, JobCommand, JobPhase, JobState
+from novel_proofer.workflow import CommandDecision, ResumeTarget, WorkflowContext, decide_command, resume_decision
 
 logger = logging.getLogger(__name__)
+
+
+def _workflow_context_for_job(st: JobStatus) -> WorkflowContext:
+    return WorkflowContext.from_values(
+        state=st.state,
+        phase=st.phase,
+        wait_reason=st.wait_reason,
+        chunks=[chunk.state for chunk in st.chunk_statuses],
+    )
+
+
+def _require_workflow_command(st: JobStatus, command: JobCommand) -> CommandDecision:
+    decision = decide_command(_workflow_context_for_job(st), command)
+    if not decision.allowed:
+        raise HTTPException(status_code=409, detail=decision.reason)
+    return decision
+
+
+def _require_resume_workflow(st: JobStatus) -> CommandDecision:
+    decision = resume_decision(_workflow_context_for_job(st))
+    if not decision.allowed:
+        raise HTTPException(status_code=409, detail=decision.reason)
+    return decision
 
 
 class _JobCommandService:
@@ -510,9 +533,7 @@ async def pause_job(job_id: str = Depends(paths._job_id_dep)) -> JobActionRespon
     st = GLOBAL_JOBS.get(job_id)
     if st is None:
         raise HTTPException(status_code=404, detail="job not found")
-    pause_guard = can_pause(st.state, st.phase)
-    if not pause_guard.allowed:
-        raise HTTPException(status_code=409, detail=pause_guard.reason)
+    _require_workflow_command(st, JobCommand.PAUSE)
     if not GLOBAL_JOBS.pause(job_id):
         raise HTTPException(status_code=409, detail="failed to pause job")
     st2 = GLOBAL_JOBS.get(job_id) or st
@@ -526,9 +547,7 @@ async def resume_job(
     st = GLOBAL_JOBS.get(job_id)
     if st is None:
         raise HTTPException(status_code=404, detail="job not found")
-    resume_guard = can_resume(st.state, st.phase)
-    if not resume_guard.allowed:
-        raise HTTPException(status_code=409, detail=resume_guard.reason)
+    resume_command = _require_resume_workflow(st)
     if not GLOBAL_JOBS.resume(job_id):
         raise HTTPException(status_code=409, detail="failed to resume job")
 
@@ -537,13 +556,17 @@ async def resume_job(
     GLOBAL_JOBS.update(job_id, last_llm_model=llm.model)
     fn: Callable[..., Any]
     args: tuple[Any, ...]
-    if resume_guard.target == ResumeTarget.VALIDATE:
+    if resume_command.target is None:
+        raise HTTPException(status_code=500, detail="workflow command target missing")
+    if resume_command.target == ResumeTarget.VALIDATE:
         fmt = st.format
         fn = run_job
         args = (job_id, paths._input_cache_path(job_id), fmt, llm)
-    else:
+    elif resume_command.target == ResumeTarget.PROCESS:
         fn = resume_paused_job
         args = (job_id, llm)
+    else:
+        raise HTTPException(status_code=500, detail="workflow command target mismatch")
 
     def _rollback_resume_state() -> None:
         GLOBAL_JOBS.pause(job_id)
@@ -566,9 +589,7 @@ async def retry_failed(
     st = GLOBAL_JOBS.get(job_id)
     if st is None:
         raise HTTPException(status_code=404, detail="job not found")
-    retry_guard = can_retry_failed(st.state, [c.state for c in st.chunk_statuses])
-    if not retry_guard.allowed:
-        raise HTTPException(status_code=409, detail=retry_guard.reason)
+    _require_workflow_command(st, JobCommand.RETRY_FAILED)
 
     failed = [c.index for c in st.chunk_statuses if c.state == ChunkState.ERROR]
 
@@ -613,9 +634,7 @@ async def merge_job(
     st = GLOBAL_JOBS.get(job_id)
     if st is None:
         raise HTTPException(status_code=404, detail="job not found")
-    merge_guard = can_merge(st.state, st.phase, [c.state for c in st.chunk_statuses])
-    if not merge_guard.allowed:
-        raise HTTPException(status_code=409, detail=merge_guard.reason)
+    _require_workflow_command(st, JobCommand.MERGE)
 
     if not GLOBAL_JOBS.resume(job_id):
         raise HTTPException(status_code=409, detail="failed to start merge")
@@ -639,6 +658,7 @@ async def reset_job(job_id: str = Depends(paths._job_id_dep)) -> JobActionRespon
     st = GLOBAL_JOBS.get(job_id)
     if st is None:
         raise HTTPException(status_code=404, detail="job not found")
+    _require_workflow_command(st, JobCommand.RESET)
 
     GLOBAL_JOBS.cancel(job_id)
 

--- a/novel_proofer/api.py
+++ b/novel_proofer/api.py
@@ -57,29 +57,21 @@ from novel_proofer.models import (
 )
 from novel_proofer.runner import merge_outputs, resume_paused_job, retry_failed_chunks, run_job
 from novel_proofer.states import ChunkState, JobCommand, JobPhase, JobState
-from novel_proofer.workflow import CommandDecision, ResumeTarget, WorkflowContext, decide_command, resume_decision
+from novel_proofer.workflow import CommandDecision, ResumeTarget, decide_command, resume_decision
+from novel_proofer.workflow_context import workflow_context_for_job
 
 logger = logging.getLogger(__name__)
 
 
-def _workflow_context_for_job(st: JobStatus) -> WorkflowContext:
-    return WorkflowContext.from_values(
-        state=st.state,
-        phase=st.phase,
-        wait_reason=st.wait_reason,
-        chunks=[chunk.state for chunk in st.chunk_statuses],
-    )
-
-
 def _require_workflow_command(st: JobStatus, command: JobCommand) -> CommandDecision:
-    decision = decide_command(_workflow_context_for_job(st), command)
+    decision = decide_command(workflow_context_for_job(st), command)
     if not decision.allowed:
         raise HTTPException(status_code=409, detail=decision.reason)
     return decision
 
 
 def _require_resume_workflow(st: JobStatus) -> CommandDecision:
-    decision = resume_decision(_workflow_context_for_job(st))
+    decision = resume_decision(workflow_context_for_job(st))
     if not decision.allowed:
         raise HTTPException(status_code=409, detail=decision.reason)
     return decision
@@ -658,9 +650,11 @@ async def reset_job(job_id: str = Depends(paths._job_id_dep)) -> JobActionRespon
     st = GLOBAL_JOBS.get(job_id)
     if st is None:
         raise HTTPException(status_code=404, detail="job not found")
-    _require_workflow_command(st, JobCommand.RESET)
+    reset_decision = _require_workflow_command(st, JobCommand.RESET)
+    assert reset_decision.next_state is not None
 
-    GLOBAL_JOBS.cancel(job_id)
+    if reset_decision.next_state.state == JobState.CANCELLED:
+        GLOBAL_JOBS.cancel(job_id)
 
     def _cleanup_and_delete() -> None:
         steps: tuple[tuple[str, Callable[[], object]], ...] = (

--- a/novel_proofer/converters.py
+++ b/novel_proofer/converters.py
@@ -26,7 +26,8 @@ from novel_proofer.models import (
 )
 from novel_proofer.paths import _rel_debug_dir, _rel_output_path
 from novel_proofer.states import ExecutionState, JobPhase, JobState, TerminalState, WaitReason
-from novel_proofer.workflow import WorkflowContext, available_commands
+from novel_proofer.workflow import available_commands
+from novel_proofer.workflow_context import workflow_context_for_job
 
 _INTERNAL_ERROR_MESSAGE = "internal server error"
 
@@ -144,23 +145,8 @@ def _job_summary_to_out(st: JobStatus) -> JobSummaryOut:
     )
 
 
-def _available_commands(st: JobStatus, *, state: JobState, phase: JobPhase) -> list[str]:
-    if st.chunk_counts:
-        context = WorkflowContext.from_counts(
-            state=state,
-            phase=phase,
-            wait_reason=st.wait_reason,
-            total_chunks=st.total_chunks,
-            chunk_counts=dict(st.chunk_counts),
-        )
-    else:
-        context = WorkflowContext.from_values(
-            state=state,
-            phase=phase,
-            wait_reason=st.wait_reason,
-            chunks=[chunk.state for chunk in st.chunk_statuses],
-        )
-    return [command.value for command in available_commands(context)]
+def _available_commands(st: JobStatus) -> list[str]:
+    return [command.value for command in available_commands(workflow_context_for_job(st))]
 
 
 def _terminal_state_for(state: JobState) -> TerminalState | None:
@@ -190,7 +176,7 @@ def _job_snapshot_fields(st: JobStatus) -> _JobSnapshotFields:
         execution_state=execution_state.value,
         wait_reason=wait_reason,
         terminal_state=terminal_state.value if terminal_state is not None else None,
-        available_commands=_available_commands(st, state=state, phase=phase),
+        available_commands=_available_commands(st),
     )
 
 

--- a/novel_proofer/converters.py
+++ b/novel_proofer/converters.py
@@ -25,7 +25,8 @@ from novel_proofer.models import (
     LLMSettings,
 )
 from novel_proofer.paths import _rel_debug_dir, _rel_output_path
-from novel_proofer.states import ExecutionState, JobCommand, JobPhase, JobState, TerminalState, WaitReason
+from novel_proofer.states import ExecutionState, JobPhase, JobState, TerminalState, WaitReason
+from novel_proofer.workflow import WorkflowContext, available_commands
 
 _INTERNAL_ERROR_MESSAGE = "internal server error"
 
@@ -144,29 +145,22 @@ def _job_summary_to_out(st: JobStatus) -> JobSummaryOut:
 
 
 def _available_commands(st: JobStatus, *, state: JobState, phase: JobPhase) -> list[str]:
-    commands: list[JobCommand] = []
-    chunk_counts = dict(st.chunk_counts or {})
-    failed_chunks = int(chunk_counts.get("error", 0) or 0)
-    all_chunks_done = st.total_chunks > 0 and int(chunk_counts.get("done", 0) or 0) == st.total_chunks
-
-    if state == JobState.PAUSED and phase == JobPhase.VALIDATE:
-        commands.append(JobCommand.VALIDATE)
-    if state == JobState.PAUSED and phase == JobPhase.PROCESS:
-        commands.append(JobCommand.PROCESS)
-    if state in {JobState.QUEUED, JobState.RUNNING} and phase == JobPhase.PROCESS:
-        commands.append(JobCommand.PAUSE)
-    if state == JobState.ERROR and failed_chunks > 0:
-        commands.append(JobCommand.RETRY_FAILED)
-    if state == JobState.PAUSED and phase == JobPhase.MERGE and all_chunks_done:
-        commands.append(JobCommand.MERGE)
-    if state not in {JobState.QUEUED, JobState.RUNNING, JobState.CANCELLED}:
-        commands.append(JobCommand.DETACH)
-    if state != JobState.CANCELLED:
-        commands.append(JobCommand.RESET)
-    if state == JobState.DONE:
-        commands.append(JobCommand.DOWNLOAD)
-
-    return [command.value for command in commands]
+    if st.chunk_counts:
+        context = WorkflowContext.from_counts(
+            state=state,
+            phase=phase,
+            wait_reason=st.wait_reason,
+            total_chunks=st.total_chunks,
+            chunk_counts=dict(st.chunk_counts),
+        )
+    else:
+        context = WorkflowContext.from_values(
+            state=state,
+            phase=phase,
+            wait_reason=st.wait_reason,
+            chunks=[chunk.state for chunk in st.chunk_statuses],
+        )
+    return [command.value for command in available_commands(context)]
 
 
 def _terminal_state_for(state: JobState) -> TerminalState | None:

--- a/novel_proofer/jobs.py
+++ b/novel_proofer/jobs.py
@@ -614,15 +614,22 @@ class JobStore:
         changed = False
         if st.state in {JobState.QUEUED, JobState.RUNNING}:
             logger.warning("restoring in-flight job as paused after restart: job_id=%s state=%s", st.job_id, st.state)
-            transition = require_event(
-                WorkflowContext.from_values(
+            if st.chunk_counts:
+                context = WorkflowContext.from_counts(
+                    state=st.state,
+                    phase=st.phase,
+                    wait_reason=st.wait_reason,
+                    total_chunks=st.total_chunks,
+                    chunk_counts=dict(st.chunk_counts),
+                )
+            else:
+                context = WorkflowContext.from_values(
                     state=st.state,
                     phase=st.phase,
                     wait_reason=st.wait_reason,
                     chunks=[chunk.state for chunk in st.chunk_statuses],
-                ),
-                WorkflowEvent.RESTART_RECOVERY,
-            )
+                )
+            transition = require_event(context, WorkflowEvent.RESTART_RECOVERY)
             assert transition.next_state is not None
             st.state = transition.next_state.state
             st.phase = transition.next_state.phase

--- a/novel_proofer/jobs.py
+++ b/novel_proofer/jobs.py
@@ -15,7 +15,14 @@ from typing import Any
 from novel_proofer.env import env_float
 from novel_proofer.formatting.config import FormatConfig
 from novel_proofer.states import ChunkState, JobPhase, JobState, WaitReason
-from novel_proofer.workflow import WorkflowInvariantError, validate_job_phase_invariants
+from novel_proofer.workflow import (
+    WorkflowContext,
+    WorkflowEvent,
+    WorkflowInvariantError,
+    WorkflowState,
+    require_event,
+    validate_job_phase_invariants,
+)
 
 logger = logging.getLogger(__name__)
 
@@ -607,8 +614,19 @@ class JobStore:
         changed = False
         if st.state in {JobState.QUEUED, JobState.RUNNING}:
             logger.warning("restoring in-flight job as paused after restart: job_id=%s state=%s", st.job_id, st.state)
-            st.state = JobState.PAUSED
-            st.wait_reason = WaitReason.SERVER_RECOVERED
+            transition = require_event(
+                WorkflowContext.from_values(
+                    state=st.state,
+                    phase=st.phase,
+                    wait_reason=st.wait_reason,
+                    chunks=[chunk.state for chunk in st.chunk_statuses],
+                ),
+                WorkflowEvent.RESTART_RECOVERY,
+            )
+            assert transition.next_state is not None
+            st.state = transition.next_state.state
+            st.phase = transition.next_state.phase
+            st.wait_reason = transition.next_state.wait_reason
             st.finished_at = None
             changed = True
 
@@ -628,7 +646,6 @@ class JobStore:
                     old_cs.state,
                 )
                 changed = True
-        return st, changed
         return st, changed
 
     def load_persisted_jobs(self) -> int:
@@ -795,6 +812,11 @@ class JobStore:
                 raise ValueError("JobStore.update: wait_reason is required when state is paused")
             if target_state != JobState.PAUSED.value and target_wait_reason is not None:
                 raise ValueError("JobStore.update: wait_reason must be None unless state is paused")
+            target_phase = str(kwargs.get("phase", st.phase))
+            try:
+                WorkflowState.from_values(target_state, target_phase, target_wait_reason)
+            except WorkflowInvariantError as e:
+                raise ValueError(f"JobStore.update: {e}") from e
             normalized = dict(kwargs)
             if "state" in normalized:
                 normalized["state"] = target_state

--- a/novel_proofer/runner.py
+++ b/novel_proofer/runner.py
@@ -22,12 +22,12 @@ from novel_proofer.llm.config import LLMConfig, build_first_chunk_config
 from novel_proofer.states import ChunkState, JobPhase, JobState, WaitReason
 from novel_proofer.workflow import (
     ProcessingFinalState,
-    WorkflowContext,
     WorkflowEvent,
     WorkflowState,
     processing_final_state,
     require_event,
 )
+from novel_proofer.workflow_context import workflow_context_for_job
 
 logger = logging.getLogger(__name__)
 
@@ -41,17 +41,8 @@ _JOB_DEBUG_README = """\
 """
 
 
-def _workflow_context_for_job(st: JobStatus) -> WorkflowContext:
-    return WorkflowContext.from_values(
-        state=st.state,
-        phase=st.phase,
-        wait_reason=st.wait_reason,
-        chunks=[chunk.state for chunk in st.chunk_statuses],
-    )
-
-
 def _workflow_event_state(st: JobStatus, event: WorkflowEvent) -> WorkflowState:
-    result = require_event(_workflow_context_for_job(st), event)
+    result = require_event(workflow_context_for_job(st), event)
     assert result.next_state is not None
     return result.next_state
 
@@ -583,7 +574,7 @@ def run_job(job_id: str, input_path: Path, fmt: FormatConfig, llm: LLMConfig) ->
                 cur = GLOBAL_JOBS.get(job_id)
                 if cur is None:
                     return
-                next_state = _workflow_event_state(cur, WorkflowEvent.EXECUTION_STOPPED)
+                next_state = WorkflowState(JobState.PAUSED, JobPhase.VALIDATE, WaitReason.USER_PAUSED)
                 GLOBAL_JOBS.update(
                     job_id,
                     state=next_state.state,

--- a/novel_proofer/runner.py
+++ b/novel_proofer/runner.py
@@ -16,11 +16,18 @@ from novel_proofer.formatting.chunking import iter_chunks_by_lines_with_first_ch
 from novel_proofer.formatting.config import FormatConfig, clamp_chunk_params
 from novel_proofer.formatting.merge import merge_text_chunks_to_path
 from novel_proofer.formatting.rules import apply_rules, is_chapter_title, is_separator_line
-from novel_proofer.jobs import GLOBAL_JOBS
+from novel_proofer.jobs import GLOBAL_JOBS, JobStatus
 from novel_proofer.llm.client import LLMError, call_llm_text_resilient_with_meta_and_raw
 from novel_proofer.llm.config import LLMConfig, build_first_chunk_config
 from novel_proofer.states import ChunkState, JobPhase, JobState, WaitReason
-from novel_proofer.workflow import ProcessingFinalState, processing_final_state
+from novel_proofer.workflow import (
+    ProcessingFinalState,
+    WorkflowContext,
+    WorkflowEvent,
+    WorkflowState,
+    processing_final_state,
+    require_event,
+)
 
 logger = logging.getLogger(__name__)
 
@@ -32,6 +39,21 @@ _JOB_DEBUG_README = """\
 - out/  : 分片最终输出（通过校验）
 - resp/ : LLM 原始响应
 """
+
+
+def _workflow_context_for_job(st: JobStatus) -> WorkflowContext:
+    return WorkflowContext.from_values(
+        state=st.state,
+        phase=st.phase,
+        wait_reason=st.wait_reason,
+        chunks=[chunk.state for chunk in st.chunk_statuses],
+    )
+
+
+def _workflow_event_state(st: JobStatus, event: WorkflowEvent) -> WorkflowState:
+    result = require_event(_workflow_context_for_job(st), event)
+    assert result.next_state is not None
+    return result.next_state
 
 
 def _ensure_job_debug_readme(work_dir: Path) -> None:
@@ -238,10 +260,12 @@ def _finalize_processing(job_id: str, total: int, error_msg: str) -> bool:
 
     final_state = processing_final_state([c.state for c in cur.chunk_statuses])
     if final_state == ProcessingFinalState.ERROR:
+        next_state = _workflow_event_state(cur, WorkflowEvent.PROCESS_FAILED)
         GLOBAL_JOBS.update(
             job_id,
-            state=JobState.ERROR,
-            phase=JobPhase.PROCESS,
+            state=next_state.state,
+            phase=next_state.phase,
+            wait_reason=next_state.wait_reason,
             finished_at=time.time(),
             error=error_msg,
             done_chunks=cur.done_chunks,
@@ -249,11 +273,12 @@ def _finalize_processing(job_id: str, total: int, error_msg: str) -> bool:
         return False
 
     # All chunks processed; wait for explicit merge.
+    next_state = _workflow_event_state(cur, WorkflowEvent.PROCESS_COMPLETE)
     GLOBAL_JOBS.update(
         job_id,
-        state=JobState.PAUSED,
-        phase=JobPhase.MERGE,
-        wait_reason=WaitReason.READY_TO_MERGE,
+        state=next_state.state,
+        phase=next_state.phase,
+        wait_reason=next_state.wait_reason,
         finished_at=None,
         error=None,
         done_chunks=total,
@@ -555,11 +580,15 @@ def run_job(job_id: str, input_path: Path, fmt: FormatConfig, llm: LLMConfig) ->
                 GLOBAL_JOBS.update(job_id, state=JobState.CANCELLED, finished_at=time.time())
                 return
             if GLOBAL_JOBS.is_paused(job_id):
+                cur = GLOBAL_JOBS.get(job_id)
+                if cur is None:
+                    return
+                next_state = _workflow_event_state(cur, WorkflowEvent.EXECUTION_STOPPED)
                 GLOBAL_JOBS.update(
                     job_id,
-                    state=JobState.PAUSED,
-                    phase=JobPhase.VALIDATE,
-                    wait_reason=WaitReason.USER_PAUSED,
+                    state=next_state.state,
+                    phase=next_state.phase,
+                    wait_reason=next_state.wait_reason,
                     finished_at=None,
                 )
                 return
@@ -579,20 +608,25 @@ def run_job(job_id: str, input_path: Path, fmt: FormatConfig, llm: LLMConfig) ->
             GLOBAL_JOBS.update(job_id, state=JobState.CANCELLED, finished_at=time.time())
             return
         if GLOBAL_JOBS.is_paused(job_id):
+            next_state = WorkflowState(JobState.PAUSED, JobPhase.PROCESS, WaitReason.USER_PAUSED)
             GLOBAL_JOBS.update(
                 job_id,
-                state=JobState.PAUSED,
-                phase=JobPhase.PROCESS,
-                wait_reason=WaitReason.USER_PAUSED,
+                state=next_state.state,
+                phase=next_state.phase,
+                wait_reason=next_state.wait_reason,
                 finished_at=None,
             )
             return
 
+        cur = GLOBAL_JOBS.get(job_id)
+        if cur is None:
+            return
+        next_state = _workflow_event_state(cur, WorkflowEvent.VALIDATION_COMPLETE)
         GLOBAL_JOBS.update(
             job_id,
-            state=JobState.PAUSED,
-            phase=JobPhase.PROCESS,
-            wait_reason=WaitReason.READY_TO_PROCESS,
+            state=next_state.state,
+            phase=next_state.phase,
+            wait_reason=next_state.wait_reason,
             finished_at=None,
             error=None,
         )
@@ -752,11 +786,32 @@ def merge_outputs(job_id: str, *, cleanup_debug_dir: bool | None = None) -> None
         )
         return
 
-    GLOBAL_JOBS.update(job_id, state=JobState.RUNNING, phase=JobPhase.MERGE, finished_at=None, error=None)
+    next_state = _workflow_event_state(st, WorkflowEvent.MERGE_STARTED)
+    if st.state == JobState.PAUSED and not GLOBAL_JOBS.resume(job_id):
+        raise RuntimeError("failed to start merge execution")
+    GLOBAL_JOBS.update(
+        job_id,
+        state=next_state.state,
+        phase=next_state.phase,
+        wait_reason=next_state.wait_reason,
+        finished_at=None,
+        error=None,
+    )
     try:
         _merge_chunk_outputs(work_dir, total, out_path)
         _post_merge_paragraph_indent_pass(out_path, st.format)
-        GLOBAL_JOBS.update(job_id, state=JobState.DONE, phase=JobPhase.DONE, finished_at=time.time(), done_chunks=total)
+        cur = GLOBAL_JOBS.get(job_id)
+        if cur is None:
+            return
+        done_state = _workflow_event_state(cur, WorkflowEvent.MERGE_COMPLETE)
+        GLOBAL_JOBS.update(
+            job_id,
+            state=done_state.state,
+            phase=done_state.phase,
+            wait_reason=done_state.wait_reason,
+            finished_at=time.time(),
+            done_chunks=total,
+        )
         do_cleanup = bool(st.cleanup_debug_dir) if cleanup_debug_dir is None else bool(cleanup_debug_dir)
         if do_cleanup:
             _cleanup_work_dir(job_id, work_dir)

--- a/novel_proofer/workflow.py
+++ b/novel_proofer/workflow.py
@@ -12,7 +12,9 @@ class WorkflowInvariantError(ValueError):
 
 
 class WorkflowTransitionError(ValueError):
-    pass
+    def __init__(self, message: str, *, code: WorkflowRejectionCode | None = None) -> None:
+        super().__init__(message)
+        self.code = code
 
 
 class ResumeTarget(StrEnum):
@@ -44,6 +46,7 @@ class WorkflowRejectionCode(StrEnum):
     CANCELLED = "cancelled"
     CHUNKS_INCOMPLETE = "chunks_incomplete"
     DONE = "done"
+    FAILED_CHUNKS = "failed_chunks"
     INVALID_PHASE = "invalid_phase"
     INVALID_STATE = "invalid_state"
     INVALID_WAIT_REASON = "invalid_wait_reason"
@@ -393,7 +396,7 @@ def require_command(context: WorkflowContext, command: JobCommand | str) -> Comm
     decision = decide_command(context, command)
     if not decision.allowed:
         assert decision.rejection is not None
-        raise WorkflowTransitionError(decision.rejection.message)
+        raise WorkflowTransitionError(decision.rejection.message, code=decision.rejection.code)
     return decision
 
 
@@ -402,7 +405,11 @@ def resume_decision(context: WorkflowContext) -> CommandDecision:
         return decide_command(context, JobCommand.VALIDATE)
     if context.workflow.phase == JobPhase.PROCESS:
         return decide_command(context, JobCommand.PROCESS)
-    return decide_command(context, JobCommand.PROCESS)
+    if context.workflow.phase == JobPhase.MERGE:
+        return CommandDecision.reject(JobCommand.PROCESS, WorkflowRejectionCode.INVALID_PHASE, "job is ready to merge")
+    if context.workflow.phase == JobPhase.DONE:
+        return CommandDecision.reject(JobCommand.PROCESS, WorkflowRejectionCode.DONE, "job is already done")
+    raise WorkflowTransitionError(f"unhandled resume phase: {context.workflow.phase.value}")
 
 
 def available_commands(context: WorkflowContext) -> list[JobCommand]:
@@ -463,7 +470,7 @@ def apply_event(context: WorkflowContext, event: WorkflowEvent | str) -> EventTr
                 evt, WorkflowRejectionCode.INVALID_PHASE, f"process cannot complete in phase={phase.value}"
             )
         if context.chunks.has_failed:
-            return _event_reject(evt, WorkflowRejectionCode.NO_FAILED_CHUNKS, "process has failed chunks")
+            return _event_reject(evt, WorkflowRejectionCode.FAILED_CHUNKS, "process has failed chunks")
         if not context.chunks.all_done:
             return _event_reject(evt, WorkflowRejectionCode.CHUNKS_INCOMPLETE, "process chunks are incomplete")
         return EventTransition.allow(evt, WorkflowState(JobState.PAUSED, JobPhase.MERGE, WaitReason.READY_TO_MERGE))
@@ -529,7 +536,7 @@ def require_event(context: WorkflowContext, event: WorkflowEvent | str) -> Event
     transition = apply_event(context, event)
     if not transition.allowed:
         assert transition.rejection is not None
-        raise WorkflowTransitionError(transition.rejection.message)
+        raise WorkflowTransitionError(transition.rejection.message, code=transition.rejection.code)
     return transition
 
 

--- a/novel_proofer/workflow.py
+++ b/novel_proofer/workflow.py
@@ -4,10 +4,14 @@ from collections.abc import Iterable
 from dataclasses import dataclass
 from enum import StrEnum
 
-from novel_proofer.states import ChunkState, JobPhase, JobState
+from novel_proofer.states import ChunkState, JobCommand, JobPhase, JobState, WaitReason
 
 
 class WorkflowInvariantError(ValueError):
+    pass
+
+
+class WorkflowTransitionError(ValueError):
     pass
 
 
@@ -21,18 +25,184 @@ class ProcessingFinalState(StrEnum):
     READY_TO_MERGE = "ready_to_merge"
 
 
+class WorkflowEvent(StrEnum):
+    CREATE_VALIDATION = "create_validation"
+    VALIDATION_COMPLETE = "validation_complete"
+    START_PROCESS = "start_process"
+    USER_PAUSE = "user_pause"
+    EXECUTION_STOPPED = "execution_stopped"
+    PROCESS_COMPLETE = "process_complete"
+    PROCESS_FAILED = "process_failed"
+    RETRY_FAILED_CHUNKS = "retry_failed_chunks"
+    MERGE_STARTED = "merge_started"
+    MERGE_COMPLETE = "merge_complete"
+    RESET_DELETE = "reset_delete"
+    RESTART_RECOVERY = "restart_recovery"
+
+
+class WorkflowRejectionCode(StrEnum):
+    CANCELLED = "cancelled"
+    CHUNKS_INCOMPLETE = "chunks_incomplete"
+    DONE = "done"
+    INVALID_PHASE = "invalid_phase"
+    INVALID_STATE = "invalid_state"
+    INVALID_WAIT_REASON = "invalid_wait_reason"
+    JOB_RUNNING = "job_running"
+    NO_FAILED_CHUNKS = "no_failed_chunks"
+    NOT_PAUSED = "not_paused"
+
+
+_WAIT_REASONS_BY_PHASE = {
+    JobPhase.VALIDATE: {WaitReason.USER_PAUSED, WaitReason.SERVER_RECOVERED},
+    JobPhase.PROCESS: {WaitReason.READY_TO_PROCESS, WaitReason.USER_PAUSED, WaitReason.SERVER_RECOVERED},
+    JobPhase.MERGE: {WaitReason.READY_TO_MERGE, WaitReason.SERVER_RECOVERED},
+}
+
+
+@dataclass(frozen=True)
+class WorkflowRejection:
+    code: WorkflowRejectionCode
+    message: str
+
+
+@dataclass(frozen=True)
+class WorkflowState:
+    state: JobState
+    phase: JobPhase
+    wait_reason: WaitReason | None = None
+
+    @classmethod
+    def from_values(
+        cls,
+        state: JobState | str,
+        phase: JobPhase | str,
+        wait_reason: WaitReason | str | None = None,
+    ) -> WorkflowState:
+        reason = None if wait_reason is None else WaitReason(wait_reason)
+        out = cls(JobState(state), JobPhase(phase), reason)
+        out.validate()
+        return out
+
+    def validate(self) -> None:
+        if self.state == JobState.PAUSED and self.wait_reason is None:
+            raise WorkflowInvariantError("paused workflow state requires wait_reason")
+        if self.state != JobState.PAUSED and self.wait_reason is not None:
+            raise WorkflowInvariantError("workflow wait_reason must be None unless state is paused")
+        if self.state == JobState.PAUSED and self.wait_reason not in _WAIT_REASONS_BY_PHASE.get(self.phase, set()):
+            raise WorkflowInvariantError(
+                f"wait_reason={self.wait_reason.value if self.wait_reason else None} is invalid for phase={self.phase.value}"
+            )
+        if self.state == JobState.DONE and self.phase != JobPhase.DONE:
+            raise WorkflowInvariantError("job.phase must be 'done' when job.state is 'done'")
+        if self.phase == JobPhase.DONE and self.state != JobState.DONE:
+            raise WorkflowInvariantError("job.state must be 'done' when job.phase is 'done'")
+
+
+@dataclass(frozen=True)
+class ChunkSummary:
+    total: int
+    pending: int = 0
+    processing: int = 0
+    retrying: int = 0
+    done: int = 0
+    error: int = 0
+
+    @classmethod
+    def from_states(cls, chunks: Iterable[ChunkState | str]) -> ChunkSummary:
+        counts = {state: 0 for state in ChunkState}
+        for chunk in chunks:
+            counts[ChunkState(chunk)] += 1
+        return cls(
+            total=sum(counts.values()),
+            pending=counts[ChunkState.PENDING],
+            processing=counts[ChunkState.PROCESSING],
+            retrying=counts[ChunkState.RETRYING],
+            done=counts[ChunkState.DONE],
+            error=counts[ChunkState.ERROR],
+        )
+
+    @classmethod
+    def from_counts(cls, *, total: int, counts: dict[str, int]) -> ChunkSummary:
+        return cls(
+            total=int(total),
+            pending=int(counts.get(ChunkState.PENDING.value, 0) or counts.get(ChunkState.PENDING, 0) or 0),
+            processing=int(counts.get(ChunkState.PROCESSING.value, 0) or counts.get(ChunkState.PROCESSING, 0) or 0),
+            retrying=int(counts.get(ChunkState.RETRYING.value, 0) or counts.get(ChunkState.RETRYING, 0) or 0),
+            done=int(counts.get(ChunkState.DONE.value, 0) or counts.get(ChunkState.DONE, 0) or 0),
+            error=int(counts.get(ChunkState.ERROR.value, 0) or counts.get(ChunkState.ERROR, 0) or 0),
+        )
+
+    @property
+    def all_done(self) -> bool:
+        return self.total > 0 and self.done == self.total
+
+    @property
+    def has_failed(self) -> bool:
+        return self.error > 0
+
+    @property
+    def has_in_flight_chunks(self) -> bool:
+        return self.processing > 0 or self.retrying > 0
+
+    def validate_for_phase(self, phase: JobPhase) -> None:
+        if phase == JobPhase.MERGE and not self.all_done:
+            raise WorkflowInvariantError("job.phase 'merge' requires every chunk to be done")
+        if phase == JobPhase.DONE and not self.all_done:
+            raise WorkflowInvariantError("job.state 'done' requires every chunk to be done")
+
+
+@dataclass(frozen=True)
+class WorkflowContext:
+    workflow: WorkflowState
+    chunks: ChunkSummary
+
+    @classmethod
+    def from_values(
+        cls,
+        *,
+        state: JobState | str,
+        phase: JobPhase | str,
+        wait_reason: WaitReason | str | None = None,
+        chunks: Iterable[ChunkState | str] = (),
+    ) -> WorkflowContext:
+        out = cls(WorkflowState.from_values(state, phase, wait_reason), ChunkSummary.from_states(chunks))
+        out.validate()
+        return out
+
+    @classmethod
+    def from_counts(
+        cls,
+        *,
+        state: JobState | str,
+        phase: JobPhase | str,
+        wait_reason: WaitReason | str | None = None,
+        total_chunks: int,
+        chunk_counts: dict[str, int],
+    ) -> WorkflowContext:
+        out = cls(
+            WorkflowState.from_values(state, phase, wait_reason),
+            ChunkSummary.from_counts(total=int(total_chunks), counts=chunk_counts),
+        )
+        out.validate()
+        return out
+
+    def validate(self) -> None:
+        self.workflow.validate()
+
+
 @dataclass(frozen=True)
 class WorkflowGuard:
     allowed: bool
     reason: str | None = None
+    rejection: WorkflowRejection | None = None
 
     @classmethod
     def allow(cls) -> WorkflowGuard:
         return cls(True)
 
     @classmethod
-    def reject(cls, reason: str) -> WorkflowGuard:
-        return cls(False, reason)
+    def reject(cls, reason: str, *, code: WorkflowRejectionCode = WorkflowRejectionCode.INVALID_STATE) -> WorkflowGuard:
+        return cls(False, reason, WorkflowRejection(code, reason))
 
 
 @dataclass(frozen=True)
@@ -44,88 +214,375 @@ class ResumeGuard(WorkflowGuard):
         return cls(True, target=target)
 
     @classmethod
-    def reject(cls, reason: str) -> ResumeGuard:
-        return cls(False, reason=reason)
+    def reject(cls, reason: str, *, code: WorkflowRejectionCode = WorkflowRejectionCode.INVALID_STATE) -> ResumeGuard:
+        return cls(False, reason=reason, rejection=WorkflowRejection(code, reason))
 
 
-def _as_state(state: JobState | str) -> JobState:
-    return JobState(state)
+@dataclass(frozen=True)
+class CommandDecision:
+    command: JobCommand
+    allowed: bool
+    next_state: WorkflowState | None = None
+    target: ResumeTarget | None = None
+    rejection: WorkflowRejection | None = None
+
+    @property
+    def reason(self) -> str | None:
+        return None if self.rejection is None else self.rejection.message
+
+    @classmethod
+    def allow(
+        cls,
+        command: JobCommand,
+        *,
+        next_state: WorkflowState | None = None,
+        target: ResumeTarget | None = None,
+    ) -> CommandDecision:
+        return cls(command=command, allowed=True, next_state=next_state, target=target)
+
+    @classmethod
+    def reject(cls, command: JobCommand, code: WorkflowRejectionCode, message: str) -> CommandDecision:
+        return cls(command=command, allowed=False, rejection=WorkflowRejection(code, message))
 
 
-def _as_phase(phase: JobPhase | str) -> JobPhase:
-    return JobPhase(phase)
+@dataclass(frozen=True)
+class EventTransition:
+    event: WorkflowEvent
+    allowed: bool
+    next_state: WorkflowState | None = None
+    rejection: WorkflowRejection | None = None
+
+    @property
+    def reason(self) -> str | None:
+        return None if self.rejection is None else self.rejection.message
+
+    @classmethod
+    def allow(cls, event: WorkflowEvent, next_state: WorkflowState) -> EventTransition:
+        return cls(event=event, allowed=True, next_state=next_state)
+
+    @classmethod
+    def reject(cls, event: WorkflowEvent, code: WorkflowRejectionCode, message: str) -> EventTransition:
+        return cls(event=event, allowed=False, rejection=WorkflowRejection(code, message))
 
 
-def _chunk_states(chunks: Iterable[ChunkState | str]) -> list[ChunkState]:
-    return [ChunkState(chunk) for chunk in chunks]
+def _in_flight(state: JobState) -> bool:
+    return state in {JobState.QUEUED, JobState.RUNNING}
 
 
 def is_in_flight_job_state(state: JobState | str) -> bool:
-    return JobState(state) in {JobState.QUEUED, JobState.RUNNING}
+    return _in_flight(JobState(state))
+
+
+def create_validation_state() -> WorkflowState:
+    return WorkflowState(JobState.QUEUED, JobPhase.VALIDATE)
+
+
+def _default_wait_reason_for_guard(state: JobState | str, phase: JobPhase | str) -> WaitReason | None:
+    if JobState(state) != JobState.PAUSED:
+        return None
+    phase_value = JobPhase(phase)
+    if phase_value == JobPhase.PROCESS:
+        return WaitReason.USER_PAUSED
+    if phase_value == JobPhase.MERGE:
+        return WaitReason.READY_TO_MERGE
+    if phase_value == JobPhase.VALIDATE:
+        return WaitReason.USER_PAUSED
+    return None
+
+
+def _reject(command: JobCommand, code: WorkflowRejectionCode, message: str) -> CommandDecision:
+    return CommandDecision.reject(command, code, message)
+
+
+def decide_command(context: WorkflowContext, command: JobCommand | str) -> CommandDecision:
+    cmd = JobCommand(command)
+    state = context.workflow.state
+    phase = context.workflow.phase
+
+    if cmd == JobCommand.VALIDATE:
+        if state == JobState.CANCELLED:
+            return _reject(cmd, WorkflowRejectionCode.CANCELLED, "job is cancelled")
+        if state == JobState.RUNNING:
+            return _reject(cmd, WorkflowRejectionCode.JOB_RUNNING, "job is running")
+        if state != JobState.PAUSED:
+            return _reject(cmd, WorkflowRejectionCode.NOT_PAUSED, "job is not paused")
+        if phase != JobPhase.VALIDATE:
+            return _reject(cmd, WorkflowRejectionCode.INVALID_PHASE, f"cannot validate job in phase={phase.value}")
+        return CommandDecision.allow(
+            cmd,
+            next_state=WorkflowState(JobState.QUEUED, JobPhase.VALIDATE),
+            target=ResumeTarget.VALIDATE,
+        )
+
+    if cmd == JobCommand.PROCESS:
+        if state == JobState.CANCELLED:
+            return _reject(cmd, WorkflowRejectionCode.CANCELLED, "job is cancelled")
+        if state == JobState.RUNNING:
+            return _reject(cmd, WorkflowRejectionCode.JOB_RUNNING, "job is running")
+        if state != JobState.PAUSED:
+            return _reject(cmd, WorkflowRejectionCode.NOT_PAUSED, "job is not paused")
+        if phase == JobPhase.MERGE:
+            return _reject(cmd, WorkflowRejectionCode.INVALID_PHASE, "job is ready to merge")
+        if phase == JobPhase.DONE:
+            return _reject(cmd, WorkflowRejectionCode.DONE, "job is already done")
+        if phase != JobPhase.PROCESS:
+            return _reject(cmd, WorkflowRejectionCode.INVALID_PHASE, f"cannot process job in phase={phase.value}")
+        return CommandDecision.allow(
+            cmd,
+            next_state=WorkflowState(JobState.QUEUED, JobPhase.PROCESS),
+            target=ResumeTarget.PROCESS,
+        )
+
+    if cmd == JobCommand.PAUSE:
+        if phase != JobPhase.PROCESS:
+            return _reject(cmd, WorkflowRejectionCode.INVALID_PHASE, f"cannot pause job in phase={phase.value}")
+        if not _in_flight(state):
+            return _reject(cmd, WorkflowRejectionCode.INVALID_STATE, f"cannot pause job in state={state.value}")
+        return CommandDecision.allow(
+            cmd,
+            next_state=WorkflowState(JobState.PAUSED, JobPhase.PROCESS, WaitReason.USER_PAUSED),
+        )
+
+    if cmd == JobCommand.RETRY_FAILED:
+        if state == JobState.CANCELLED:
+            return _reject(cmd, WorkflowRejectionCode.CANCELLED, "job is cancelled")
+        if state == JobState.RUNNING:
+            return _reject(cmd, WorkflowRejectionCode.JOB_RUNNING, "job is running")
+        if state != JobState.ERROR:
+            return _reject(cmd, WorkflowRejectionCode.INVALID_STATE, f"job is not in error state (state={state.value})")
+        if not context.chunks.has_failed:
+            return _reject(cmd, WorkflowRejectionCode.NO_FAILED_CHUNKS, "no failed chunks to retry")
+        return CommandDecision.allow(cmd, next_state=WorkflowState(JobState.QUEUED, JobPhase.PROCESS))
+
+    if cmd == JobCommand.MERGE:
+        if state == JobState.CANCELLED:
+            return _reject(cmd, WorkflowRejectionCode.CANCELLED, "job is cancelled")
+        if state == JobState.RUNNING:
+            return _reject(cmd, WorkflowRejectionCode.JOB_RUNNING, "job is running")
+        if state != JobState.PAUSED:
+            return _reject(cmd, WorkflowRejectionCode.NOT_PAUSED, f"job is not paused (state={state.value})")
+        if phase != JobPhase.MERGE:
+            return _reject(cmd, WorkflowRejectionCode.INVALID_PHASE, f"job is not ready to merge (phase={phase.value})")
+        if not context.chunks.all_done:
+            return _reject(
+                cmd, WorkflowRejectionCode.CHUNKS_INCOMPLETE, "job is not ready to merge (chunks incomplete)"
+            )
+        return CommandDecision.allow(cmd, next_state=WorkflowState(JobState.QUEUED, JobPhase.MERGE))
+
+    if cmd == JobCommand.DETACH:
+        if state in {JobState.QUEUED, JobState.RUNNING, JobState.CANCELLED}:
+            return _reject(cmd, WorkflowRejectionCode.INVALID_STATE, f"cannot detach job in state={state.value}")
+        return CommandDecision.allow(cmd, next_state=context.workflow)
+
+    if cmd == JobCommand.RESET:
+        if state == JobState.CANCELLED:
+            return _reject(cmd, WorkflowRejectionCode.CANCELLED, "job is cancelled")
+        if state in {JobState.DONE, JobState.ERROR}:
+            return CommandDecision.allow(cmd, next_state=context.workflow)
+        return CommandDecision.allow(cmd, next_state=WorkflowState(JobState.CANCELLED, phase))
+
+    if cmd == JobCommand.DOWNLOAD:
+        if state != JobState.DONE:
+            return _reject(cmd, WorkflowRejectionCode.INVALID_STATE, f"cannot download job in state={state.value}")
+        return CommandDecision.allow(cmd, next_state=context.workflow)
+
+    raise WorkflowTransitionError(f"unhandled workflow command: {cmd.value}")
+
+
+def require_command(context: WorkflowContext, command: JobCommand | str) -> CommandDecision:
+    decision = decide_command(context, command)
+    if not decision.allowed:
+        assert decision.rejection is not None
+        raise WorkflowTransitionError(decision.rejection.message)
+    return decision
+
+
+def resume_decision(context: WorkflowContext) -> CommandDecision:
+    if context.workflow.phase == JobPhase.VALIDATE:
+        return decide_command(context, JobCommand.VALIDATE)
+    if context.workflow.phase == JobPhase.PROCESS:
+        return decide_command(context, JobCommand.PROCESS)
+    return decide_command(context, JobCommand.PROCESS)
+
+
+def available_commands(context: WorkflowContext) -> list[JobCommand]:
+    return [command for command in JobCommand if decide_command(context, command).allowed]
+
+
+def _event_reject(event: WorkflowEvent, code: WorkflowRejectionCode, message: str) -> EventTransition:
+    return EventTransition.reject(event, code, message)
+
+
+def apply_event(context: WorkflowContext, event: WorkflowEvent | str) -> EventTransition:
+    evt = WorkflowEvent(event)
+    state = context.workflow.state
+    phase = context.workflow.phase
+
+    if evt == WorkflowEvent.CREATE_VALIDATION:
+        return EventTransition.allow(evt, create_validation_state())
+
+    if evt == WorkflowEvent.VALIDATION_COMPLETE:
+        if phase != JobPhase.VALIDATE:
+            return _event_reject(
+                evt, WorkflowRejectionCode.INVALID_PHASE, f"validation cannot complete in phase={phase.value}"
+            )
+        if not _in_flight(state):
+            return _event_reject(
+                evt, WorkflowRejectionCode.INVALID_STATE, f"validation cannot complete in state={state.value}"
+            )
+        return EventTransition.allow(evt, WorkflowState(JobState.PAUSED, JobPhase.PROCESS, WaitReason.READY_TO_PROCESS))
+
+    if evt == WorkflowEvent.START_PROCESS:
+        decision = decide_command(context, JobCommand.PROCESS)
+        if not decision.allowed:
+            assert decision.rejection is not None
+            return EventTransition.reject(evt, decision.rejection.code, decision.rejection.message)
+        assert decision.next_state is not None
+        return EventTransition.allow(evt, decision.next_state)
+
+    if evt == WorkflowEvent.USER_PAUSE:
+        decision = decide_command(context, JobCommand.PAUSE)
+        if not decision.allowed:
+            assert decision.rejection is not None
+            return EventTransition.reject(evt, decision.rejection.code, decision.rejection.message)
+        assert decision.next_state is not None
+        return EventTransition.allow(evt, decision.next_state)
+
+    if evt == WorkflowEvent.EXECUTION_STOPPED:
+        if not _in_flight(state):
+            return _event_reject(
+                evt, WorkflowRejectionCode.INVALID_STATE, f"execution is not active (state={state.value})"
+            )
+        if phase == JobPhase.DONE:
+            return _event_reject(evt, WorkflowRejectionCode.DONE, "job is already done")
+        return EventTransition.allow(evt, WorkflowState(JobState.PAUSED, phase, WaitReason.USER_PAUSED))
+
+    if evt == WorkflowEvent.PROCESS_COMPLETE:
+        if phase != JobPhase.PROCESS:
+            return _event_reject(
+                evt, WorkflowRejectionCode.INVALID_PHASE, f"process cannot complete in phase={phase.value}"
+            )
+        if context.chunks.has_failed:
+            return _event_reject(evt, WorkflowRejectionCode.NO_FAILED_CHUNKS, "process has failed chunks")
+        if not context.chunks.all_done:
+            return _event_reject(evt, WorkflowRejectionCode.CHUNKS_INCOMPLETE, "process chunks are incomplete")
+        return EventTransition.allow(evt, WorkflowState(JobState.PAUSED, JobPhase.MERGE, WaitReason.READY_TO_MERGE))
+
+    if evt == WorkflowEvent.PROCESS_FAILED:
+        if phase != JobPhase.PROCESS:
+            return _event_reject(
+                evt, WorkflowRejectionCode.INVALID_PHASE, f"process cannot fail in phase={phase.value}"
+            )
+        if not context.chunks.has_failed:
+            return _event_reject(evt, WorkflowRejectionCode.NO_FAILED_CHUNKS, "process has no failed chunks")
+        return EventTransition.allow(evt, WorkflowState(JobState.ERROR, JobPhase.PROCESS))
+
+    if evt == WorkflowEvent.RETRY_FAILED_CHUNKS:
+        decision = decide_command(context, JobCommand.RETRY_FAILED)
+        if not decision.allowed:
+            assert decision.rejection is not None
+            return EventTransition.reject(evt, decision.rejection.code, decision.rejection.message)
+        assert decision.next_state is not None
+        return EventTransition.allow(evt, decision.next_state)
+
+    if evt == WorkflowEvent.MERGE_STARTED:
+        if phase != JobPhase.MERGE:
+            return _event_reject(evt, WorkflowRejectionCode.INVALID_PHASE, f"merge cannot start in phase={phase.value}")
+        if state == JobState.CANCELLED:
+            return _event_reject(evt, WorkflowRejectionCode.CANCELLED, "job is cancelled")
+        if state not in {JobState.PAUSED, JobState.QUEUED, JobState.RUNNING}:
+            return _event_reject(evt, WorkflowRejectionCode.INVALID_STATE, f"merge cannot start in state={state.value}")
+        if not context.chunks.all_done:
+            return _event_reject(evt, WorkflowRejectionCode.CHUNKS_INCOMPLETE, "merge chunks are incomplete")
+        return EventTransition.allow(evt, WorkflowState(JobState.RUNNING, JobPhase.MERGE))
+
+    if evt == WorkflowEvent.MERGE_COMPLETE:
+        if phase != JobPhase.MERGE:
+            return _event_reject(
+                evt, WorkflowRejectionCode.INVALID_PHASE, f"merge cannot complete in phase={phase.value}"
+            )
+        if not context.chunks.all_done:
+            return _event_reject(evt, WorkflowRejectionCode.CHUNKS_INCOMPLETE, "merge chunks are incomplete")
+        return EventTransition.allow(evt, WorkflowState(JobState.DONE, JobPhase.DONE))
+
+    if evt == WorkflowEvent.RESET_DELETE:
+        decision = decide_command(context, JobCommand.RESET)
+        if not decision.allowed:
+            assert decision.rejection is not None
+            return EventTransition.reject(evt, decision.rejection.code, decision.rejection.message)
+        assert decision.next_state is not None
+        return EventTransition.allow(evt, decision.next_state)
+
+    if evt == WorkflowEvent.RESTART_RECOVERY:
+        if not _in_flight(state):
+            return _event_reject(
+                evt, WorkflowRejectionCode.INVALID_STATE, f"job is not in-flight (state={state.value})"
+            )
+        if phase == JobPhase.DONE:
+            return _event_reject(evt, WorkflowRejectionCode.DONE, "job is already done")
+        return EventTransition.allow(evt, WorkflowState(JobState.PAUSED, phase, WaitReason.SERVER_RECOVERED))
+
+    raise WorkflowTransitionError(f"unhandled workflow event: {evt.value}")
+
+
+def require_event(context: WorkflowContext, event: WorkflowEvent | str) -> EventTransition:
+    transition = apply_event(context, event)
+    if not transition.allowed:
+        assert transition.rejection is not None
+        raise WorkflowTransitionError(transition.rejection.message)
+    return transition
 
 
 def can_pause(state: JobState | str, phase: JobPhase | str) -> WorkflowGuard:
-    st = _as_state(state)
-    ph = _as_phase(phase)
-    if ph != JobPhase.PROCESS:
-        return WorkflowGuard.reject(f"cannot pause job in phase={ph.value}")
-    if st not in {JobState.QUEUED, JobState.RUNNING}:
-        return WorkflowGuard.reject(f"cannot pause job in state={st.value}")
-    return WorkflowGuard.allow()
+    context = WorkflowContext.from_values(
+        state=state, phase=phase, wait_reason=_default_wait_reason_for_guard(state, phase), chunks=()
+    )
+    decision = decide_command(context, JobCommand.PAUSE)
+    if decision.allowed:
+        return WorkflowGuard.allow()
+    assert decision.rejection is not None
+    return WorkflowGuard.reject(decision.rejection.message, code=decision.rejection.code)
 
 
 def can_resume(state: JobState | str, phase: JobPhase | str) -> ResumeGuard:
-    st = _as_state(state)
-    ph = _as_phase(phase)
-    if st == JobState.RUNNING:
-        return ResumeGuard.reject("job is running")
-    if st == JobState.CANCELLED:
-        return ResumeGuard.reject("job is cancelled")
-    if st != JobState.PAUSED:
-        return ResumeGuard.reject("job is not paused")
-    if ph == JobPhase.MERGE:
-        return ResumeGuard.reject("job is ready to merge")
-    if ph == JobPhase.DONE:
-        return ResumeGuard.reject("job is already done")
-    if ph == JobPhase.VALIDATE:
-        return ResumeGuard.allow_target(ResumeTarget.VALIDATE)
-    if ph == JobPhase.PROCESS:
-        return ResumeGuard.allow_target(ResumeTarget.PROCESS)
-    return ResumeGuard.reject(f"cannot resume job in phase={ph.value}")
+    context = WorkflowContext.from_values(
+        state=state, phase=phase, wait_reason=_default_wait_reason_for_guard(state, phase), chunks=()
+    )
+    decision = resume_decision(context)
+    if decision.allowed:
+        assert decision.target is not None
+        return ResumeGuard.allow_target(decision.target)
+    assert decision.rejection is not None
+    return ResumeGuard.reject(decision.rejection.message, code=decision.rejection.code)
 
 
 def can_retry_failed(state: JobState | str, chunks: Iterable[ChunkState | str]) -> WorkflowGuard:
-    st = _as_state(state)
-    if st == JobState.CANCELLED:
-        return WorkflowGuard.reject("job is cancelled")
-    if st == JobState.RUNNING:
-        return WorkflowGuard.reject("job is running")
-    if st != JobState.ERROR:
-        return WorkflowGuard.reject(f"job is not in error state (state={st.value})")
-    if not any(chunk == ChunkState.ERROR for chunk in _chunk_states(chunks)):
-        return WorkflowGuard.reject("no failed chunks to retry")
-    return WorkflowGuard.allow()
+    context = WorkflowContext.from_values(
+        state=state,
+        phase=JobPhase.PROCESS,
+        wait_reason=_default_wait_reason_for_guard(state, JobPhase.PROCESS),
+        chunks=chunks,
+    )
+    decision = decide_command(context, JobCommand.RETRY_FAILED)
+    if decision.allowed:
+        return WorkflowGuard.allow()
+    assert decision.rejection is not None
+    return WorkflowGuard.reject(decision.rejection.message, code=decision.rejection.code)
 
 
 def can_merge(state: JobState | str, phase: JobPhase | str, chunks: Iterable[ChunkState | str]) -> WorkflowGuard:
-    st = _as_state(state)
-    ph = _as_phase(phase)
-    chunk_states = _chunk_states(chunks)
-    if st == JobState.CANCELLED:
-        return WorkflowGuard.reject("job is cancelled")
-    if st == JobState.RUNNING:
-        return WorkflowGuard.reject("job is running")
-    if st != JobState.PAUSED:
-        return WorkflowGuard.reject(f"job is not paused (state={st.value})")
-    if ph != JobPhase.MERGE:
-        return WorkflowGuard.reject(f"job is not ready to merge (phase={ph.value})")
-    if not chunk_states or any(chunk != ChunkState.DONE for chunk in chunk_states):
-        return WorkflowGuard.reject("job is not ready to merge (chunks incomplete)")
-    return WorkflowGuard.allow()
+    context = WorkflowContext.from_values(
+        state=state, phase=phase, wait_reason=_default_wait_reason_for_guard(state, phase), chunks=chunks
+    )
+    decision = decide_command(context, JobCommand.MERGE)
+    if decision.allowed:
+        return WorkflowGuard.allow()
+    assert decision.rejection is not None
+    return WorkflowGuard.reject(decision.rejection.message, code=decision.rejection.code)
 
 
 def processing_final_state(chunks: Iterable[ChunkState | str]) -> ProcessingFinalState:
-    chunk_states = _chunk_states(chunks)
+    chunk_states = [ChunkState(chunk) for chunk in chunks]
     if any(chunk == ChunkState.ERROR for chunk in chunk_states):
         return ProcessingFinalState.ERROR
     return ProcessingFinalState.READY_TO_MERGE
@@ -136,14 +593,8 @@ def validate_job_phase_invariants(
     phase: JobPhase | str,
     chunks: Iterable[ChunkState | str],
 ) -> None:
-    state_value = JobState(state)
-    phase_value = JobPhase(phase)
-    chunk_states = _chunk_states(chunks)
-    if state_value == JobState.DONE and phase_value != JobPhase.DONE:
-        raise WorkflowInvariantError("job.phase must be 'done' when job.state is 'done'")
-    if phase_value == JobPhase.DONE and state_value != JobState.DONE:
-        raise WorkflowInvariantError("job.state must be 'done' when job.phase is 'done'")
-    if phase_value == JobPhase.MERGE and any(chunk != ChunkState.DONE for chunk in chunk_states):
-        raise WorkflowInvariantError("job.phase 'merge' requires every chunk to be done")
-    if state_value == JobState.DONE and any(chunk != ChunkState.DONE for chunk in chunk_states):
-        raise WorkflowInvariantError("job.state 'done' requires every chunk to be done")
+    context = WorkflowContext.from_values(
+        state=state, phase=phase, wait_reason=_default_wait_reason_for_guard(state, phase), chunks=chunks
+    )
+    context.validate()
+    context.chunks.validate_for_phase(context.workflow.phase)

--- a/novel_proofer/workflow_context.py
+++ b/novel_proofer/workflow_context.py
@@ -1,0 +1,21 @@
+from __future__ import annotations
+
+from novel_proofer.jobs import JobStatus
+from novel_proofer.workflow import WorkflowContext
+
+
+def workflow_context_for_job(st: JobStatus) -> WorkflowContext:
+    if st.chunk_counts:
+        return WorkflowContext.from_counts(
+            state=st.state,
+            phase=st.phase,
+            wait_reason=st.wait_reason,
+            total_chunks=st.total_chunks,
+            chunk_counts=dict(st.chunk_counts),
+        )
+    return WorkflowContext.from_values(
+        state=st.state,
+        phase=st.phase,
+        wait_reason=st.wait_reason,
+        chunks=[chunk.state for chunk in st.chunk_statuses],
+    )

--- a/tests/api/test_endpoints.py
+++ b/tests/api/test_endpoints.py
@@ -525,6 +525,26 @@ def test_reset_job_deletes_job() -> None:
         GLOBAL_JOBS.delete(job.job_id)
 
 
+def test_reset_completed_job_deletes_without_forcing_cancel(monkeypatch: pytest.MonkeyPatch) -> None:
+    client = TestClient(api.app)
+
+    job = GLOBAL_JOBS.create("in.txt", "out.txt", total_chunks=0)
+    GLOBAL_JOBS.update(job.job_id, state="done", phase="done")
+
+    def fail_cancel(job_id: str) -> bool:
+        raise AssertionError(f"cancel should not be called for completed reset: {job_id}")
+
+    monkeypatch.setattr(api.GLOBAL_JOBS, "cancel", fail_cancel)
+
+    try:
+        r = client.post(f"/api/v1/jobs/{job.job_id}/reset")
+        assert r.status_code == 200, r.text
+        assert r.json().get("ok") is True
+        assert GLOBAL_JOBS.get(job.job_id) is None
+    finally:
+        GLOBAL_JOBS.delete(job.job_id)
+
+
 def test_resume_job_returns_409_when_background_submit_rejects(monkeypatch: pytest.MonkeyPatch):
     client = TestClient(api.app)
 

--- a/tests/api/test_endpoints.py
+++ b/tests/api/test_endpoints.py
@@ -454,7 +454,7 @@ def test_job_input_stats_endpoint(monkeypatch: pytest.MonkeyPatch):
         job4_dir = jobs_dir / job4.job_id
         job4_dir.mkdir(parents=True, exist_ok=True)
         (job4_dir / "x.txt").write_text("x", encoding="utf-8")
-        GLOBAL_JOBS.update(job4.job_id, state="done")
+        GLOBAL_JOBS.update(job4.job_id, state="done", phase="done")
 
         input_cache = out_dir / ".inputs" / f"{job4.job_id}.txt"
         input_cache.parent.mkdir(parents=True, exist_ok=True)

--- a/tests/jobs/test_store.py
+++ b/tests/jobs/test_store.py
@@ -83,6 +83,24 @@ def test_job_store_update_respects_started_at_and_pause_rules() -> None:
     assert js.is_paused(job_id) is False
 
 
+def test_job_store_update_rejects_invalid_workflow_combinations() -> None:
+    js = JobStore()
+    st = js.create("in.txt", "out.txt", total_chunks=0)
+    job_id = st.job_id
+
+    with pytest.raises(ValueError, match="job\\.phase must be 'done'"):
+        js.update(job_id, state="done", phase="process")
+
+    with pytest.raises(ValueError, match="job\\.state must be 'done'"):
+        js.update(job_id, state="running", phase="done")
+
+    with pytest.raises(ValueError, match="wait_reason is required when state is paused"):
+        js.update(job_id, state="paused")
+
+    with pytest.raises(ValueError, match="wait_reason=ready_to_merge is invalid for phase=process"):
+        js.update(job_id, state="paused", phase="process", wait_reason="ready_to_merge")
+
+
 def test_job_store_update_chunk_tracks_done_chunks() -> None:
     js = JobStore()
     st = js.create("in.txt", "out.txt", total_chunks=2)

--- a/tests/jobs/test_store.py
+++ b/tests/jobs/test_store.py
@@ -79,7 +79,7 @@ def test_job_store_update_respects_started_at_and_pause_rules() -> None:
         js.update(job_id, wait_reason="bogus")
 
     # Marking terminal state should clear paused flag.
-    js.update(job_id, state="done", finished_at=time.time())
+    js.update(job_id, state="done", phase="done", finished_at=time.time())
     assert js.is_paused(job_id) is False
 
 

--- a/tests/runner/test_extra_coverage.py
+++ b/tests/runner/test_extra_coverage.py
@@ -389,7 +389,13 @@ def test_retry_failed_and_resume_paused_branches(monkeypatch: pytest.MonkeyPatch
         try:
             out_path = base / "o2.txt"
             out_path.write_text("x", encoding="utf-8")
-            GLOBAL_JOBS.update(job3_id, work_dir=str(base / "w2"), output_path=str(out_path), cleanup_debug_dir=False)
+            GLOBAL_JOBS.update(
+                job3_id,
+                phase="process",
+                work_dir=str(base / "w2"),
+                output_path=str(out_path),
+                cleanup_debug_dir=False,
+            )
             GLOBAL_JOBS.init_chunks(job3_id, total_chunks=1)
             GLOBAL_JOBS.update_chunk(job3_id, 0, state="done")
             runner.retry_failed_chunks(job3_id, llm)
@@ -436,7 +442,11 @@ def test_retry_failed_and_resume_paused_branches(monkeypatch: pytest.MonkeyPatch
             (work_dir / "out").mkdir(parents=True, exist_ok=True)
             (work_dir / "out" / "000000.txt").write_text("x", encoding="utf-8")
             GLOBAL_JOBS.update(
-                job6_id, work_dir=str(work_dir), output_path=str(base / "o5.txt"), cleanup_debug_dir=False
+                job6_id,
+                phase="process",
+                work_dir=str(work_dir),
+                output_path=str(base / "o5.txt"),
+                cleanup_debug_dir=False,
             )
             GLOBAL_JOBS.init_chunks(job6_id, total_chunks=1)
             GLOBAL_JOBS.update_chunk(job6_id, 0, state="done")

--- a/tests/runner/test_run_job.py
+++ b/tests/runner/test_run_job.py
@@ -25,6 +25,41 @@ def test_run_job_missing_paths_sets_error() -> None:
         GLOBAL_JOBS.delete(job_id)
 
 
+def test_run_job_pause_during_validation_stays_in_validate_phase(monkeypatch: pytest.MonkeyPatch) -> None:
+    with tempfile.TemporaryDirectory() as td:
+        work_dir = Path(td) / "work"
+        out_path = Path(td) / "out.txt"
+        input_path = Path(td) / "in.txt"
+        input_path.write_text("第1章\r\n\r\n你好。\r\n", encoding="utf-8")
+
+        job = GLOBAL_JOBS.create("in.txt", "out.txt", total_chunks=0)
+        job_id = job.job_id
+
+        def pause_before_first_chunk(*args: object, **kwargs: object):
+            assert GLOBAL_JOBS.pause(job_id) is True
+            yield "第1章\n\n你好。"
+
+        monkeypatch.setattr(runner, "iter_chunks_by_lines_with_first_chunk_max_from_file", pause_before_first_chunk)
+        try:
+            GLOBAL_JOBS.update(job_id, work_dir=str(work_dir), output_path=str(out_path))
+
+            runner.run_job(
+                job_id,
+                input_path,
+                FormatConfig(max_chunk_chars=2000),
+                LLMConfig(base_url="http://example.com", model="m", max_concurrency=1),
+            )
+
+            st = GLOBAL_JOBS.get(job_id)
+            assert st is not None
+            assert st.state == "paused"
+            assert st.phase == "validate"
+            assert st.wait_reason == "user_paused"
+            assert st.error is None
+        finally:
+            GLOBAL_JOBS.delete(job_id)
+
+
 def test_run_job_local_mode_cleans_up_by_default(monkeypatch: pytest.MonkeyPatch) -> None:
     monkeypatch.setattr(
         runner,

--- a/tests/test_workflow.py
+++ b/tests/test_workflow.py
@@ -10,6 +10,7 @@ from novel_proofer.workflow import (
     WorkflowEvent,
     WorkflowInvariantError,
     WorkflowRejectionCode,
+    WorkflowTransitionError,
     apply_event,
     available_commands,
     can_merge,
@@ -19,6 +20,9 @@ from novel_proofer.workflow import (
     create_validation_state,
     decide_command,
     processing_final_state,
+    require_command,
+    require_event,
+    resume_decision,
     validate_job_phase_invariants,
 )
 
@@ -235,6 +239,18 @@ def test_illegal_commands_return_typed_rejections(
     assert decision.rejection.message == reason
 
 
+def test_require_command_preserves_rejection_message_and_code() -> None:
+    context = WorkflowContext.from_values(state=JobState.RUNNING, phase=JobPhase.PROCESS)
+    decision = decide_command(context, JobCommand.PROCESS)
+
+    with pytest.raises(WorkflowTransitionError) as exc_info:
+        require_command(context, JobCommand.PROCESS)
+
+    assert str(exc_info.value) == decision.reason
+    assert decision.rejection is not None
+    assert exc_info.value.code == decision.rejection.code
+
+
 @pytest.mark.parametrize(
     ("context", "event", "next_state"),
     [
@@ -347,6 +363,16 @@ def test_workflow_events_are_table_driven(
         ),
         (
             WorkflowContext.from_values(
+                state=JobState.RUNNING,
+                phase=JobPhase.PROCESS,
+                chunks=[ChunkState.DONE, ChunkState.ERROR],
+            ),
+            WorkflowEvent.PROCESS_COMPLETE,
+            WorkflowRejectionCode.FAILED_CHUNKS,
+            "process has failed chunks",
+        ),
+        (
+            WorkflowContext.from_values(
                 state=JobState.PAUSED,
                 phase=JobPhase.PROCESS,
                 wait_reason=WaitReason.USER_PAUSED,
@@ -375,6 +401,44 @@ def test_illegal_events_return_typed_rejections(
     assert transition.rejection is not None
     assert transition.rejection.code == code
     assert transition.rejection.message == reason
+
+
+def test_require_event_preserves_rejection_message_and_code() -> None:
+    context = WorkflowContext.from_values(
+        state=JobState.RUNNING,
+        phase=JobPhase.PROCESS,
+        chunks=[ChunkState.DONE, ChunkState.ERROR],
+    )
+    transition = apply_event(context, WorkflowEvent.PROCESS_COMPLETE)
+
+    with pytest.raises(WorkflowTransitionError) as exc_info:
+        require_event(context, WorkflowEvent.PROCESS_COMPLETE)
+
+    assert str(exc_info.value) == transition.reason
+    assert transition.rejection is not None
+    assert exc_info.value.code == transition.rejection.code
+
+
+def test_resume_decision_rejects_merge_and_done_without_process_fallthrough() -> None:
+    merge_context = WorkflowContext.from_values(
+        state=JobState.PAUSED,
+        phase=JobPhase.MERGE,
+        wait_reason=WaitReason.READY_TO_MERGE,
+        chunks=[ChunkState.DONE],
+    )
+    done_context = WorkflowContext.from_values(state=JobState.DONE, phase=JobPhase.DONE, chunks=[ChunkState.DONE])
+
+    merge_decision = resume_decision(merge_context)
+    done_decision = resume_decision(done_context)
+
+    assert merge_decision.allowed is False
+    assert merge_decision.rejection is not None
+    assert merge_decision.rejection.code == WorkflowRejectionCode.INVALID_PHASE
+    assert merge_decision.rejection.message == "job is ready to merge"
+    assert done_decision.allowed is False
+    assert done_decision.rejection is not None
+    assert done_decision.rejection.code == WorkflowRejectionCode.DONE
+    assert done_decision.rejection.message == "job is already done"
 
 
 @pytest.mark.parametrize("phase", list(JobPhase))

--- a/tests/test_workflow.py
+++ b/tests/test_workflow.py
@@ -2,15 +2,22 @@ from __future__ import annotations
 
 import pytest
 
-from novel_proofer.states import ChunkState, JobPhase, JobState
+from novel_proofer.states import ChunkState, JobCommand, JobPhase, JobState, WaitReason
 from novel_proofer.workflow import (
     ProcessingFinalState,
     ResumeTarget,
+    WorkflowContext,
+    WorkflowEvent,
     WorkflowInvariantError,
+    WorkflowRejectionCode,
+    apply_event,
+    available_commands,
     can_merge,
     can_pause,
     can_resume,
     can_retry_failed,
+    create_validation_state,
+    decide_command,
     processing_final_state,
     validate_job_phase_invariants,
 )
@@ -94,3 +101,335 @@ def test_persisted_phase_invariants_are_centralized() -> None:
 
     with pytest.raises(WorkflowInvariantError, match="requires every chunk to be done"):
         validate_job_phase_invariants(JobState.PAUSED, JobPhase.MERGE, [ChunkState.DONE, ChunkState.ERROR])
+
+
+@pytest.mark.parametrize(
+    ("context", "command", "next_state", "target"),
+    [
+        (
+            WorkflowContext.from_values(
+                state=JobState.PAUSED,
+                phase=JobPhase.VALIDATE,
+                wait_reason=WaitReason.USER_PAUSED,
+            ),
+            JobCommand.VALIDATE,
+            (JobState.QUEUED, JobPhase.VALIDATE, None),
+            ResumeTarget.VALIDATE,
+        ),
+        (
+            WorkflowContext.from_values(
+                state=JobState.PAUSED,
+                phase=JobPhase.PROCESS,
+                wait_reason=WaitReason.READY_TO_PROCESS,
+            ),
+            JobCommand.PROCESS,
+            (JobState.QUEUED, JobPhase.PROCESS, None),
+            ResumeTarget.PROCESS,
+        ),
+        (
+            WorkflowContext.from_values(state=JobState.RUNNING, phase=JobPhase.PROCESS),
+            JobCommand.PAUSE,
+            (JobState.PAUSED, JobPhase.PROCESS, WaitReason.USER_PAUSED),
+            None,
+        ),
+        (
+            WorkflowContext.from_values(
+                state=JobState.ERROR,
+                phase=JobPhase.PROCESS,
+                chunks=[ChunkState.DONE, ChunkState.ERROR],
+            ),
+            JobCommand.RETRY_FAILED,
+            (JobState.QUEUED, JobPhase.PROCESS, None),
+            None,
+        ),
+        (
+            WorkflowContext.from_values(
+                state=JobState.PAUSED,
+                phase=JobPhase.MERGE,
+                wait_reason=WaitReason.READY_TO_MERGE,
+                chunks=[ChunkState.DONE, ChunkState.DONE],
+            ),
+            JobCommand.MERGE,
+            (JobState.QUEUED, JobPhase.MERGE, None),
+            None,
+        ),
+        (
+            WorkflowContext.from_values(state=JobState.DONE, phase=JobPhase.DONE, chunks=[ChunkState.DONE]),
+            JobCommand.DOWNLOAD,
+            (JobState.DONE, JobPhase.DONE, None),
+            None,
+        ),
+    ],
+)
+def test_command_decisions_return_explicit_next_state_and_target(
+    context: WorkflowContext,
+    command: JobCommand,
+    next_state: tuple[JobState, JobPhase, WaitReason | None],
+    target: ResumeTarget | None,
+) -> None:
+    decision = decide_command(context, command)
+
+    assert decision.allowed is True
+    assert decision.rejection is None
+    assert decision.target == target
+    assert decision.next_state is not None
+    assert (decision.next_state.state, decision.next_state.phase, decision.next_state.wait_reason) == next_state
+
+
+@pytest.mark.parametrize(
+    ("context", "command", "code", "reason"),
+    [
+        (
+            WorkflowContext.from_values(state=JobState.RUNNING, phase=JobPhase.VALIDATE),
+            JobCommand.PAUSE,
+            WorkflowRejectionCode.INVALID_PHASE,
+            "cannot pause job in phase=validate",
+        ),
+        (
+            WorkflowContext.from_values(
+                state=JobState.PAUSED,
+                phase=JobPhase.MERGE,
+                wait_reason=WaitReason.READY_TO_MERGE,
+                chunks=[ChunkState.DONE],
+            ),
+            JobCommand.PROCESS,
+            WorkflowRejectionCode.INVALID_PHASE,
+            "job is ready to merge",
+        ),
+        (
+            WorkflowContext.from_values(state=JobState.ERROR, phase=JobPhase.PROCESS, chunks=[ChunkState.DONE]),
+            JobCommand.RETRY_FAILED,
+            WorkflowRejectionCode.NO_FAILED_CHUNKS,
+            "no failed chunks to retry",
+        ),
+        (
+            WorkflowContext.from_values(
+                state=JobState.PAUSED,
+                phase=JobPhase.MERGE,
+                wait_reason=WaitReason.READY_TO_MERGE,
+                chunks=[ChunkState.DONE, ChunkState.PENDING],
+            ),
+            JobCommand.MERGE,
+            WorkflowRejectionCode.CHUNKS_INCOMPLETE,
+            "job is not ready to merge (chunks incomplete)",
+        ),
+        (
+            WorkflowContext.from_values(state=JobState.CANCELLED, phase=JobPhase.PROCESS),
+            JobCommand.RESET,
+            WorkflowRejectionCode.CANCELLED,
+            "job is cancelled",
+        ),
+    ],
+)
+def test_illegal_commands_return_typed_rejections(
+    context: WorkflowContext,
+    command: JobCommand,
+    code: WorkflowRejectionCode,
+    reason: str,
+) -> None:
+    decision = decide_command(context, command)
+
+    assert decision.allowed is False
+    assert decision.rejection is not None
+    assert decision.rejection.code == code
+    assert decision.rejection.message == reason
+
+
+@pytest.mark.parametrize(
+    ("context", "event", "next_state"),
+    [
+        (
+            WorkflowContext.from_values(state=JobState.QUEUED, phase=JobPhase.VALIDATE),
+            WorkflowEvent.CREATE_VALIDATION,
+            (JobState.QUEUED, JobPhase.VALIDATE, None),
+        ),
+        (
+            WorkflowContext.from_values(state=JobState.RUNNING, phase=JobPhase.VALIDATE),
+            WorkflowEvent.VALIDATION_COMPLETE,
+            (JobState.PAUSED, JobPhase.PROCESS, WaitReason.READY_TO_PROCESS),
+        ),
+        (
+            WorkflowContext.from_values(
+                state=JobState.PAUSED,
+                phase=JobPhase.PROCESS,
+                wait_reason=WaitReason.READY_TO_PROCESS,
+            ),
+            WorkflowEvent.START_PROCESS,
+            (JobState.QUEUED, JobPhase.PROCESS, None),
+        ),
+        (
+            WorkflowContext.from_values(state=JobState.RUNNING, phase=JobPhase.PROCESS),
+            WorkflowEvent.USER_PAUSE,
+            (JobState.PAUSED, JobPhase.PROCESS, WaitReason.USER_PAUSED),
+        ),
+        (
+            WorkflowContext.from_values(
+                state=JobState.RUNNING,
+                phase=JobPhase.PROCESS,
+                chunks=[ChunkState.DONE, ChunkState.DONE],
+            ),
+            WorkflowEvent.PROCESS_COMPLETE,
+            (JobState.PAUSED, JobPhase.MERGE, WaitReason.READY_TO_MERGE),
+        ),
+        (
+            WorkflowContext.from_values(
+                state=JobState.RUNNING,
+                phase=JobPhase.PROCESS,
+                chunks=[ChunkState.DONE, ChunkState.ERROR],
+            ),
+            WorkflowEvent.PROCESS_FAILED,
+            (JobState.ERROR, JobPhase.PROCESS, None),
+        ),
+        (
+            WorkflowContext.from_values(
+                state=JobState.ERROR,
+                phase=JobPhase.PROCESS,
+                chunks=[ChunkState.ERROR],
+            ),
+            WorkflowEvent.RETRY_FAILED_CHUNKS,
+            (JobState.QUEUED, JobPhase.PROCESS, None),
+        ),
+        (
+            WorkflowContext.from_values(
+                state=JobState.QUEUED,
+                phase=JobPhase.MERGE,
+                chunks=[ChunkState.DONE],
+            ),
+            WorkflowEvent.MERGE_STARTED,
+            (JobState.RUNNING, JobPhase.MERGE, None),
+        ),
+        (
+            WorkflowContext.from_values(
+                state=JobState.RUNNING,
+                phase=JobPhase.MERGE,
+                chunks=[ChunkState.DONE],
+            ),
+            WorkflowEvent.MERGE_COMPLETE,
+            (JobState.DONE, JobPhase.DONE, None),
+        ),
+        (
+            WorkflowContext.from_values(state=JobState.RUNNING, phase=JobPhase.PROCESS),
+            WorkflowEvent.RESTART_RECOVERY,
+            (JobState.PAUSED, JobPhase.PROCESS, WaitReason.SERVER_RECOVERED),
+        ),
+        (
+            WorkflowContext.from_values(state=JobState.QUEUED, phase=JobPhase.PROCESS),
+            WorkflowEvent.RESET_DELETE,
+            (JobState.CANCELLED, JobPhase.PROCESS, None),
+        ),
+    ],
+)
+def test_workflow_events_are_table_driven(
+    context: WorkflowContext,
+    event: WorkflowEvent,
+    next_state: tuple[JobState, JobPhase, WaitReason | None],
+) -> None:
+    transition = apply_event(context, event)
+
+    assert transition.allowed is True
+    assert transition.rejection is None
+    assert transition.next_state is not None
+    assert (transition.next_state.state, transition.next_state.phase, transition.next_state.wait_reason) == next_state
+
+
+@pytest.mark.parametrize(
+    ("context", "event", "code", "reason"),
+    [
+        (
+            WorkflowContext.from_values(
+                state=JobState.RUNNING,
+                phase=JobPhase.PROCESS,
+                chunks=[ChunkState.DONE, ChunkState.PENDING],
+            ),
+            WorkflowEvent.PROCESS_COMPLETE,
+            WorkflowRejectionCode.CHUNKS_INCOMPLETE,
+            "process chunks are incomplete",
+        ),
+        (
+            WorkflowContext.from_values(
+                state=JobState.PAUSED,
+                phase=JobPhase.PROCESS,
+                wait_reason=WaitReason.USER_PAUSED,
+            ),
+            WorkflowEvent.RESTART_RECOVERY,
+            WorkflowRejectionCode.INVALID_STATE,
+            "job is not in-flight (state=paused)",
+        ),
+        (
+            WorkflowContext.from_values(state=JobState.RUNNING, phase=JobPhase.PROCESS),
+            WorkflowEvent.MERGE_STARTED,
+            WorkflowRejectionCode.INVALID_PHASE,
+            "merge cannot start in phase=process",
+        ),
+    ],
+)
+def test_illegal_events_return_typed_rejections(
+    context: WorkflowContext,
+    event: WorkflowEvent,
+    code: WorkflowRejectionCode,
+    reason: str,
+) -> None:
+    transition = apply_event(context, event)
+
+    assert transition.allowed is False
+    assert transition.rejection is not None
+    assert transition.rejection.code == code
+    assert transition.rejection.message == reason
+
+
+@pytest.mark.parametrize("phase", list(JobPhase))
+def test_pause_is_legal_only_for_in_flight_process_phase(phase: JobPhase) -> None:
+    if phase == JobPhase.DONE:
+        with pytest.raises(WorkflowInvariantError, match=r"job\.state must be 'done'"):
+            WorkflowContext.from_values(state=JobState.RUNNING, phase=phase)
+        return
+
+    decision = decide_command(WorkflowContext.from_values(state=JobState.RUNNING, phase=phase), JobCommand.PAUSE)
+
+    if phase == JobPhase.PROCESS:
+        assert decision.allowed is True
+    else:
+        assert decision.allowed is False
+        assert decision.rejection is not None
+        assert decision.rejection.code == WorkflowRejectionCode.INVALID_PHASE
+
+
+@pytest.mark.parametrize(
+    "wait_reason",
+    [WaitReason.READY_TO_PROCESS, WaitReason.USER_PAUSED, WaitReason.SERVER_RECOVERED],
+)
+def test_process_resume_allows_process_wait_reasons(wait_reason: WaitReason) -> None:
+    context = WorkflowContext.from_values(state=JobState.PAUSED, phase=JobPhase.PROCESS, wait_reason=wait_reason)
+
+    decision = decide_command(context, JobCommand.PROCESS)
+
+    assert decision.allowed is True
+    assert decision.target == ResumeTarget.PROCESS
+
+
+def test_wait_reasons_are_phase_specific() -> None:
+    with pytest.raises(WorkflowInvariantError, match="wait_reason=ready_to_merge is invalid for phase=process"):
+        WorkflowContext.from_values(
+            state=JobState.PAUSED,
+            phase=JobPhase.PROCESS,
+            wait_reason=WaitReason.READY_TO_MERGE,
+        )
+
+
+def test_available_commands_are_derived_from_workflow_decisions() -> None:
+    context = WorkflowContext.from_values(
+        state=JobState.PAUSED,
+        phase=JobPhase.MERGE,
+        wait_reason=WaitReason.READY_TO_MERGE,
+        chunks=[ChunkState.DONE, ChunkState.DONE],
+    )
+
+    assert available_commands(context) == [JobCommand.MERGE, JobCommand.DETACH, JobCommand.RESET]
+
+
+def test_create_validation_state_is_the_only_new_job_workflow_entry() -> None:
+    state = create_validation_state()
+
+    assert state.state == JobState.QUEUED
+    assert state.phase == JobPhase.VALIDATE
+    assert state.wait_reason is None


### PR DESCRIPTION
## Summary
- Add an explicit pure workflow transition layer with `WorkflowContext`, typed command decisions, typed event transitions, and typed rejection codes.
- Route API command guards and snapshot `available_commands` through the shared workflow module.
- Use workflow events for runner completion, merge start/finish, and restart recovery state healing.
- Strengthen table-driven workflow tests and document the new coverage.

## Notes
- This PR is intentionally based on `main` and does not include the open #77 lifecycle PR changes.
- Invalid phase/state/wait combinations now fail explicitly instead of being normalized silently.

## Validation
- `uv run --frozen --no-sync ruff format --check`
- `uv run --frozen --no-sync ruff check`
- `uv run --frozen --no-sync python -m mypy novel_proofer`
- `uv run --frozen --no-sync python -m pytest -q -m "not llm_integration"`
- `uv run --frozen --no-sync python tools/export-openapi.py --check`
- `uv run --frozen --no-sync python tools/check-large-files.py`

Part of #74.
Closes #78.

## Summary by Sourcery

Centralize workflow transition logic into a typed workflow module and route API, runner, converters, and job store behavior through this shared transition layer.

New Features:
- Introduce a typed workflow context with explicit command decisions, event transitions, and rejection codes for job state management.
- Expose a workflow-driven computation of available job commands for use in API and UI responses.

Bug Fixes:
- Make invalid combinations of job state, phase, wait reason, and chunk status fail explicitly rather than being silently normalized.
- Ensure persisted jobs restored after restart transition to a valid paused state via the workflow event model.

Enhancements:
- Refactor runner, API endpoints, converters, and job store to use centralized workflow command and event helpers instead of duplicating state-transition rules.
- Add table-driven workflow tests covering command decisions, event transitions, wait-reason invariants, and available-commands derivation.
- Tighten job store update validation by reusing workflow state invariants in persistence logic.

Documentation:
- Document workflow test coverage and invariants in the test case catalog.