### PR TITLE
refactor(workflow): persist durable job records

### DIFF
--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -63,6 +63,7 @@ novel_proofer/
 | `api.py` | REST 端点、请求验证 | `create_job()`, `get_job()`, `pause_job()` |
 | `background.py` | 后台任务线程池（job 级并发） | `submit()`, `shutdown()` |
 | `dotenv_store.py` | 本地 `.env` 读写（保留未知键/注释） | `read_llm_defaults()`, `update_llm_defaults()` |
+| `job_records.py` | 严格 `JobRecord` 持久化 schema 与解析 | `job_record_to_payload()`, `job_record_from_payload()` |
 | `logging_setup.py` | 文件日志初始化 | `ensure_file_logging()` |
 | `jobs.py` | 线程安全状态管理（含持久化） | `configure_persistence()`, `load_persisted_jobs()`, `get_summary()`, `get_chunks_page()` |
 | `runner.py` | 流程编排 | `run_job()`, `_llm_worker()`, `_finalize_job()` |

--- a/docs/TESTCASES.md
+++ b/docs/TESTCASES.md
@@ -65,6 +65,15 @@
 | `tests/jobs/test_store.py::test_job_store_pause_resume_and_delete` | `pause/resume/delete` 的幂等性与返回值（重复操作返回 `False`）以及 paused 状态开关。 |
 | `tests/jobs/test_store.py::test_job_store_ignores_unknown_jobs_and_cancelled_updates` | 对未知 job 的操作应无副作用；对已标记为 `cancelled` 的 job 的 `update()/update_chunk()` 应 no-op，避免状态被“复活”。 |
 | `tests/jobs/test_store.py::test_job_store_persistence_is_throttled_and_flushable` | 持久化写盘不应发生在每次 `update_chunk()` 的热路径；dirty 更新应被节流并可通过 `flush_persistence()` 主动触发落盘。 |
+| `tests/jobs/test_store.py::test_job_record_rejects_missing_phase` | `JobRecord` schema 缺少 workflow phase 时明确失败。 |
+| `tests/jobs/test_store.py::test_job_record_rejects_unknown_root_fields` | `JobRecord` 根对象不允许混入旧 schema 字段。 |
+| `tests/jobs/test_store.py::test_job_record_rejects_paused_without_wait_reason` | `JobRecord` 中 paused workflow 必须带 durable wait reason。 |
+| `tests/jobs/test_store.py::test_job_record_rejects_non_paused_with_wait_reason` | `JobRecord` 中非 paused workflow 不允许携带 wait reason。 |
+| `tests/jobs/test_store.py::test_job_store_persists_job_record_without_volatile_execution` | 持久化文件写入 v4 `job_record`，不会把 running job 或 processing chunk 当作 durable truth 落盘。 |
+| `tests/jobs/test_store.py::test_job_store_load_persisted_jobs_loads_clean_record` | 加载干净 `JobRecord` 后恢复为对应 runtime `JobStatus`。 |
+| `tests/jobs/test_store.py::test_job_store_load_persisted_jobs_preserves_server_recovered_record` | 已经 server-recovered 的 record 会保持明确恢复态。 |
+| `tests/jobs/test_store.py::test_job_store_load_persisted_jobs_rejects_corrupt_record` | 非法 `JobRecord` 会中止加载并给出显式错误，不跳过或降级。 |
+| `tests/jobs/test_store.py::test_job_store_load_persisted_jobs_restores_in_flight_record_as_paused` | 若 record 中仍出现 in-flight 状态，加载时恢复为 `server_recovered` 且 chunk 回到 `pending`。 |
 
 ## tests/test_workflow.py
 

--- a/docs/TESTCASES.md
+++ b/docs/TESTCASES.md
@@ -67,6 +67,7 @@
 | `tests/jobs/test_store.py::test_job_store_persistence_is_throttled_and_flushable` | 持久化写盘不应发生在每次 `update_chunk()` 的热路径；dirty 更新应被节流并可通过 `flush_persistence()` 主动触发落盘。 |
 | `tests/jobs/test_store.py::test_job_record_rejects_missing_phase` | `JobRecord` schema 缺少 workflow phase 时明确失败。 |
 | `tests/jobs/test_store.py::test_job_record_rejects_unknown_root_fields` | `JobRecord` 根对象不允许混入旧 schema 字段。 |
+| `tests/jobs/test_store.py::test_job_record_rejects_mismatched_chunk_counts` | `JobRecord` 的 chunk counts 必须与 chunk items 一致。 |
 | `tests/jobs/test_store.py::test_job_record_rejects_paused_without_wait_reason` | `JobRecord` 中 paused workflow 必须带 durable wait reason。 |
 | `tests/jobs/test_store.py::test_job_record_rejects_non_paused_with_wait_reason` | `JobRecord` 中非 paused workflow 不允许携带 wait reason。 |
 | `tests/jobs/test_store.py::test_job_store_persists_job_record_without_volatile_execution` | 持久化文件写入 v4 `job_record`，不会把 running job 或 processing chunk 当作 durable truth 落盘。 |

--- a/novel_proofer/job_records.py
+++ b/novel_proofer/job_records.py
@@ -1,0 +1,500 @@
+from __future__ import annotations
+
+import re
+from dataclasses import dataclass, fields
+from typing import Any
+
+from novel_proofer.formatting.config import FormatConfig
+from novel_proofer.states import ChunkState, JobPhase, JobState, WaitReason
+from novel_proofer.workflow import WorkflowContext, WorkflowInvariantError
+
+JOB_RECORD_VERSION = 4
+
+_JOB_ID_RE = re.compile(r"^[0-9a-f]{32}$", re.IGNORECASE)
+_JOB_PHASES = {phase.value for phase in JobPhase}
+_JOB_STATES = {state.value for state in JobState}
+_WAIT_REASONS = {reason.value for reason in WaitReason}
+_CHUNK_STATE_VALUES = {state.value for state in ChunkState}
+_CHUNK_STATES = (
+    ChunkState.PENDING,
+    ChunkState.PROCESSING,
+    ChunkState.RETRYING,
+    ChunkState.DONE,
+    ChunkState.ERROR,
+)
+_FORMAT_DEFAULTS = FormatConfig()
+
+
+@dataclass(frozen=True)
+class ChunkRecord:
+    index: int
+    state: str
+    started_at: float | None
+    finished_at: float | None
+    retries: int
+    last_error_code: int | None
+    last_error_message: str | None
+    llm_model: str | None
+    input_chars: int | None
+    output_chars: int | None
+
+
+@dataclass(frozen=True)
+class WorkflowRecord:
+    state: str
+    phase: str
+    wait_reason: str | None
+
+
+@dataclass(frozen=True)
+class TimestampRecord:
+    created_at: float
+    started_at: float | None
+    finished_at: float | None
+
+
+@dataclass(frozen=True)
+class ArtifactRecord:
+    input_filename: str
+    output_filename: str
+    output_path: str | None
+    work_dir: str | None
+    cleanup_debug_dir: bool
+
+
+@dataclass(frozen=True)
+class LLMRecord:
+    last_error_code: int | None
+    last_retry_count: int
+    last_llm_model: str | None
+
+
+@dataclass(frozen=True)
+class ChunkSetRecord:
+    total: int
+    done: int
+    counts: dict[str, int]
+    items: list[ChunkRecord]
+
+
+@dataclass(frozen=True)
+class DiagnosticsRecord:
+    stats: dict[str, int]
+    error: str | None
+
+
+@dataclass(frozen=True)
+class JobRecord:
+    job_id: str
+    workflow: WorkflowRecord
+    timestamps: TimestampRecord
+    artifacts: ArtifactRecord
+    format: FormatConfig
+    llm: LLMRecord
+    chunks: ChunkSetRecord
+    diagnostics: DiagnosticsRecord
+
+
+def new_chunk_counts() -> dict[str, int]:
+    return {state.value: 0 for state in _CHUNK_STATES}
+
+
+def compute_chunk_counts(chunks: list[ChunkRecord]) -> dict[str, int]:
+    out = new_chunk_counts()
+    for chunk in chunks:
+        out[chunk.state] = out.get(chunk.state, 0) + 1
+    return out
+
+
+def job_record_to_payload(record: JobRecord) -> dict[str, Any]:
+    return {
+        "version": JOB_RECORD_VERSION,
+        "job_record": {
+            "job_id": record.job_id,
+            "workflow": {
+                "state": record.workflow.state,
+                "phase": record.workflow.phase,
+                "wait_reason": record.workflow.wait_reason,
+            },
+            "timestamps": {
+                "created_at": record.timestamps.created_at,
+                "started_at": record.timestamps.started_at,
+                "finished_at": record.timestamps.finished_at,
+            },
+            "artifacts": {
+                "input_filename": record.artifacts.input_filename,
+                "output_filename": record.artifacts.output_filename,
+                "output_path": record.artifacts.output_path,
+                "work_dir": record.artifacts.work_dir,
+                "cleanup_debug_dir": record.artifacts.cleanup_debug_dir,
+            },
+            "format": _format_config_to_dict(record.format),
+            "llm": {
+                "last_error_code": record.llm.last_error_code,
+                "last_retry_count": record.llm.last_retry_count,
+                "last_llm_model": record.llm.last_llm_model,
+            },
+            "chunks": {
+                "total": record.chunks.total,
+                "done": record.chunks.done,
+                "counts": dict(record.chunks.counts),
+                "items": [_chunk_to_dict(chunk) for chunk in record.chunks.items],
+            },
+            "diagnostics": {
+                "stats": dict(record.diagnostics.stats),
+                "error": record.diagnostics.error,
+            },
+        },
+    }
+
+
+def job_record_from_payload(raw_payload: object) -> JobRecord:
+    payload = _require_dict(raw_payload, context="job record file")
+    _reject_unknown_fields(payload, {"version", "job_record"}, context="job record file")
+    version = _parse_int(
+        _require_field(payload, "version", context="job record file"),
+        context="job record file.version",
+    )
+    if version != JOB_RECORD_VERSION:
+        raise ValueError(f"unsupported job record version {version}; expected {JOB_RECORD_VERSION}")
+
+    record = _require_dict(_require_field(payload, "job_record", context="job record file"), context="job_record")
+    _reject_unknown_fields(
+        record,
+        {"job_id", "workflow", "timestamps", "artifacts", "format", "llm", "chunks", "diagnostics"},
+        context="job_record",
+    )
+
+    job_id = _parse_str(_require_field(record, "job_id", context="job_record"), context="job_record.job_id")
+    if not _JOB_ID_RE.fullmatch(job_id):
+        raise ValueError("job_record.job_id must be a 32-character lowercase hex string")
+
+    workflow = _workflow_from_dict(_require_field(record, "workflow", context="job_record"))
+    timestamps = _timestamps_from_dict(_require_field(record, "timestamps", context="job_record"))
+    artifacts = _artifacts_from_dict(_require_field(record, "artifacts", context="job_record"))
+    llm = _llm_from_dict(_require_field(record, "llm", context="job_record"))
+    chunks = _chunks_from_dict(_require_field(record, "chunks", context="job_record"))
+    diagnostics = _diagnostics_from_dict(_require_field(record, "diagnostics", context="job_record"))
+
+    try:
+        context = WorkflowContext.from_values(
+            state=workflow.state,
+            phase=workflow.phase,
+            wait_reason=workflow.wait_reason,
+            chunks=[chunk.state for chunk in chunks.items],
+        )
+        context.chunks.validate_for_phase(context.workflow.phase)
+    except WorkflowInvariantError as e:
+        raise ValueError(str(e)) from e
+
+    return JobRecord(
+        job_id=job_id,
+        workflow=workflow,
+        timestamps=timestamps,
+        artifacts=artifacts,
+        format=_format_config_from_dict(_require_field(record, "format", context="job_record")),
+        llm=llm,
+        chunks=chunks,
+        diagnostics=diagnostics,
+    )
+
+
+def _require_dict(raw: object, *, context: str) -> dict[str, Any]:
+    if not isinstance(raw, dict):
+        raise ValueError(f"{context} must be an object")
+    return raw
+
+
+def _reject_unknown_fields(raw: dict[str, Any], allowed: set[str], *, context: str) -> None:
+    extra = sorted(set(raw) - allowed)
+    if extra:
+        raise ValueError(f"{context} contains unknown fields: {', '.join(extra)}")
+
+
+def _require_field(raw: dict[str, Any], key: str, *, context: str) -> Any:
+    if key not in raw:
+        raise ValueError(f"{context} missing field {key!r}")
+    return raw[key]
+
+
+def _parse_int(raw: Any, *, context: str) -> int:
+    if isinstance(raw, bool) or not isinstance(raw, int):
+        raise ValueError(f"{context} must be an integer")
+    return int(raw)
+
+
+def _parse_float(raw: Any, *, context: str) -> float:
+    if isinstance(raw, bool) or not isinstance(raw, int | float):
+        raise ValueError(f"{context} must be a number")
+    return float(raw)
+
+
+def _parse_optional_float(raw: Any, *, context: str) -> float | None:
+    if raw is None:
+        return None
+    return _parse_float(raw, context=context)
+
+
+def _parse_bool(raw: Any, *, context: str) -> bool:
+    if not isinstance(raw, bool):
+        raise ValueError(f"{context} must be a boolean")
+    return raw
+
+
+def _parse_optional_int(raw: Any, *, context: str) -> int | None:
+    if raw is None:
+        return None
+    return _parse_int(raw, context=context)
+
+
+def _parse_non_negative_int(raw: Any, *, context: str) -> int:
+    value = _parse_int(raw, context=context)
+    if value < 0:
+        raise ValueError(f"{context} must be >= 0")
+    return value
+
+
+def _parse_optional_non_negative_int(raw: Any, *, context: str) -> int | None:
+    if raw is None:
+        return None
+    return _parse_non_negative_int(raw, context=context)
+
+
+def _parse_str(raw: Any, *, context: str, allow_empty: bool = False) -> str:
+    if not isinstance(raw, str):
+        raise ValueError(f"{context} must be a string")
+    if not allow_empty and not raw.strip():
+        raise ValueError(f"{context} must not be empty")
+    return raw
+
+
+def _parse_optional_str(raw: Any, *, context: str) -> str | None:
+    if raw is None:
+        return None
+    return _parse_str(raw, context=context, allow_empty=True)
+
+
+def _parse_enum(raw: Any, *, context: str, allowed: set[str]) -> str:
+    value = _parse_str(raw, context=context)
+    if value not in allowed:
+        raise ValueError(f"{context} must be one of {sorted(allowed)!r}")
+    return value
+
+
+def _parse_stats(raw: object) -> dict[str, int]:
+    stats = _require_dict(raw, context="job_record.diagnostics.stats")
+    out: dict[str, int] = {}
+    for key, value in stats.items():
+        if not isinstance(key, str) or not key:
+            raise ValueError("job_record.diagnostics.stats keys must be non-empty strings")
+        out[key] = _parse_non_negative_int(value, context=f"job_record.diagnostics.stats[{key!r}]")
+    return out
+
+
+def _format_config_to_dict(config: FormatConfig) -> dict[str, Any]:
+    return {field.name: getattr(config, field.name) for field in fields(FormatConfig)}
+
+
+def _format_config_from_dict(raw: object) -> FormatConfig:
+    config = _require_dict(raw, context="job_record.format")
+    allowed = {field.name for field in fields(FormatConfig)}
+    _reject_unknown_fields(config, allowed, context="job_record.format")
+    kwargs: dict[str, Any] = {}
+    for field in fields(FormatConfig):
+        value = _require_field(config, field.name, context="job_record.format")
+        default = getattr(_FORMAT_DEFAULTS, field.name)
+        if isinstance(default, bool):
+            kwargs[field.name] = _parse_bool(value, context=f"job_record.format.{field.name}")
+            continue
+        if isinstance(default, int):
+            kwargs[field.name] = _parse_int(value, context=f"job_record.format.{field.name}")
+            continue
+        kwargs[field.name] = value
+    return FormatConfig(**kwargs)
+
+
+def _chunk_to_dict(chunk: ChunkRecord) -> dict[str, Any]:
+    return {
+        "index": chunk.index,
+        "state": chunk.state,
+        "started_at": chunk.started_at,
+        "finished_at": chunk.finished_at,
+        "retries": chunk.retries,
+        "last_error_code": chunk.last_error_code,
+        "last_error_message": chunk.last_error_message,
+        "llm_model": chunk.llm_model,
+        "input_chars": chunk.input_chars,
+        "output_chars": chunk.output_chars,
+    }
+
+
+def _chunk_from_dict(raw_item: object) -> ChunkRecord:
+    raw = _require_dict(raw_item, context="chunk")
+    _reject_unknown_fields(
+        raw,
+        {
+            "index",
+            "state",
+            "started_at",
+            "finished_at",
+            "retries",
+            "last_error_code",
+            "last_error_message",
+            "llm_model",
+            "input_chars",
+            "output_chars",
+        },
+        context="chunk",
+    )
+    return ChunkRecord(
+        index=_parse_non_negative_int(_require_field(raw, "index", context="chunk"), context="chunk.index"),
+        state=_parse_enum(
+            _require_field(raw, "state", context="chunk"), context="chunk.state", allowed=_CHUNK_STATE_VALUES
+        ),
+        started_at=_parse_optional_float(raw.get("started_at"), context="chunk.started_at"),
+        finished_at=_parse_optional_float(raw.get("finished_at"), context="chunk.finished_at"),
+        retries=_parse_non_negative_int(_require_field(raw, "retries", context="chunk"), context="chunk.retries"),
+        last_error_code=_parse_optional_int(raw.get("last_error_code"), context="chunk.last_error_code"),
+        last_error_message=_parse_optional_str(raw.get("last_error_message"), context="chunk.last_error_message"),
+        llm_model=_parse_optional_str(raw.get("llm_model"), context="chunk.llm_model"),
+        input_chars=_parse_optional_non_negative_int(raw.get("input_chars"), context="chunk.input_chars"),
+        output_chars=_parse_optional_non_negative_int(raw.get("output_chars"), context="chunk.output_chars"),
+    )
+
+
+def _workflow_from_dict(raw_value: object) -> WorkflowRecord:
+    raw = _require_dict(raw_value, context="job_record.workflow")
+    _reject_unknown_fields(raw, {"state", "phase", "wait_reason"}, context="job_record.workflow")
+    state = _parse_enum(
+        _require_field(raw, "state", context="job_record.workflow"),
+        context="job_record.workflow.state",
+        allowed=_JOB_STATES,
+    )
+    phase = _parse_enum(
+        _require_field(raw, "phase", context="job_record.workflow"),
+        context="job_record.workflow.phase",
+        allowed=_JOB_PHASES,
+    )
+    wait_reason = _parse_optional_str(raw.get("wait_reason"), context="job_record.workflow.wait_reason")
+    if wait_reason is not None and wait_reason not in _WAIT_REASONS:
+        raise ValueError(f"job_record.workflow.wait_reason must be one of {sorted(_WAIT_REASONS)!r}")
+    return WorkflowRecord(state=state, phase=phase, wait_reason=wait_reason)
+
+
+def _timestamps_from_dict(raw_value: object) -> TimestampRecord:
+    raw = _require_dict(raw_value, context="job_record.timestamps")
+    _reject_unknown_fields(raw, {"created_at", "started_at", "finished_at"}, context="job_record.timestamps")
+    return TimestampRecord(
+        created_at=_parse_float(
+            _require_field(raw, "created_at", context="job_record.timestamps"),
+            context="job_record.timestamps.created_at",
+        ),
+        started_at=_parse_optional_float(raw.get("started_at"), context="job_record.timestamps.started_at"),
+        finished_at=_parse_optional_float(raw.get("finished_at"), context="job_record.timestamps.finished_at"),
+    )
+
+
+def _artifacts_from_dict(raw_value: object) -> ArtifactRecord:
+    raw = _require_dict(raw_value, context="job_record.artifacts")
+    _reject_unknown_fields(
+        raw,
+        {"input_filename", "output_filename", "output_path", "work_dir", "cleanup_debug_dir"},
+        context="job_record.artifacts",
+    )
+    return ArtifactRecord(
+        input_filename=_parse_str(
+            _require_field(raw, "input_filename", context="job_record.artifacts"),
+            context="job_record.artifacts.input_filename",
+        ),
+        output_filename=_parse_str(
+            _require_field(raw, "output_filename", context="job_record.artifacts"),
+            context="job_record.artifacts.output_filename",
+        ),
+        output_path=_parse_optional_str(raw.get("output_path"), context="job_record.artifacts.output_path"),
+        work_dir=_parse_optional_str(raw.get("work_dir"), context="job_record.artifacts.work_dir"),
+        cleanup_debug_dir=_parse_bool(
+            _require_field(raw, "cleanup_debug_dir", context="job_record.artifacts"),
+            context="job_record.artifacts.cleanup_debug_dir",
+        ),
+    )
+
+
+def _llm_from_dict(raw_value: object) -> LLMRecord:
+    raw = _require_dict(raw_value, context="job_record.llm")
+    _reject_unknown_fields(
+        raw,
+        {"last_error_code", "last_retry_count", "last_llm_model"},
+        context="job_record.llm",
+    )
+    return LLMRecord(
+        last_error_code=_parse_optional_int(raw.get("last_error_code"), context="job_record.llm.last_error_code"),
+        last_retry_count=_parse_non_negative_int(
+            _require_field(raw, "last_retry_count", context="job_record.llm"),
+            context="job_record.llm.last_retry_count",
+        ),
+        last_llm_model=_parse_optional_str(raw.get("last_llm_model"), context="job_record.llm.last_llm_model"),
+    )
+
+
+def _parse_chunk_counts(raw_value: object, chunks: list[ChunkRecord]) -> dict[str, int]:
+    counts = _require_dict(raw_value, context="job_record.chunks.counts")
+    expected = {state.value for state in _CHUNK_STATES}
+    extra = sorted(set(counts) - expected)
+    if extra:
+        raise ValueError(f"job_record.chunks.counts contains unknown fields: {', '.join(extra)}")
+    missing = sorted(expected - set(counts))
+    if missing:
+        raise ValueError(f"job_record.chunks.counts missing fields: {', '.join(missing)}")
+    out = {
+        key: _parse_non_negative_int(value, context=f"job_record.chunks.counts[{key!r}]")
+        for key, value in counts.items()
+    }
+    computed = compute_chunk_counts(chunks)
+    if out != computed:
+        raise ValueError("job_record.chunks.counts does not match chunk items")
+    return out
+
+
+def _chunks_from_dict(raw_value: object) -> ChunkSetRecord:
+    raw = _require_dict(raw_value, context="job_record.chunks")
+    _reject_unknown_fields(raw, {"total", "done", "counts", "items"}, context="job_record.chunks")
+
+    raw_items = _require_field(raw, "items", context="job_record.chunks")
+    if not isinstance(raw_items, list):
+        raise ValueError("job_record.chunks.items must be a list")
+    chunks = [_chunk_from_dict(item) for item in raw_items]
+    for expected_index, chunk in enumerate(chunks):
+        if chunk.index != expected_index:
+            raise ValueError(
+                f"chunk index mismatch at position {expected_index}: expected {expected_index}, got {chunk.index}"
+            )
+
+    total = _parse_non_negative_int(
+        _require_field(raw, "total", context="job_record.chunks"),
+        context="job_record.chunks.total",
+    )
+    done = _parse_non_negative_int(
+        _require_field(raw, "done", context="job_record.chunks"),
+        context="job_record.chunks.done",
+    )
+    counted_done = sum(1 for chunk in chunks if chunk.state == ChunkState.DONE)
+    if total != len(chunks):
+        raise ValueError("job_record.chunks.total does not match chunk items length")
+    if done != counted_done:
+        raise ValueError("job_record.chunks.done does not match chunk items")
+
+    return ChunkSetRecord(
+        total=total,
+        done=done,
+        counts=_parse_chunk_counts(_require_field(raw, "counts", context="job_record.chunks"), chunks),
+        items=chunks,
+    )
+
+
+def _diagnostics_from_dict(raw_value: object) -> DiagnosticsRecord:
+    raw = _require_dict(raw_value, context="job_record.diagnostics")
+    _reject_unknown_fields(raw, {"stats", "error"}, context="job_record.diagnostics")
+    return DiagnosticsRecord(
+        stats=_parse_stats(_require_field(raw, "stats", context="job_record.diagnostics")),
+        error=_parse_optional_str(raw.get("error"), context="job_record.diagnostics.error"),
+    )

--- a/novel_proofer/jobs.py
+++ b/novel_proofer/jobs.py
@@ -8,12 +8,24 @@ import re
 import threading
 import time
 import uuid
-from dataclasses import asdict, dataclass, field, fields, replace
+from dataclasses import dataclass, field, replace
 from pathlib import Path
 from typing import Any
 
 from novel_proofer.env import env_float
 from novel_proofer.formatting.config import FormatConfig
+from novel_proofer.job_records import (
+    ArtifactRecord,
+    ChunkRecord,
+    ChunkSetRecord,
+    DiagnosticsRecord,
+    JobRecord,
+    LLMRecord,
+    TimestampRecord,
+    WorkflowRecord,
+    job_record_from_payload,
+    job_record_to_payload,
+)
 from novel_proofer.states import ChunkState, JobPhase, JobState, WaitReason
 from novel_proofer.workflow import (
     WorkflowContext,
@@ -21,18 +33,14 @@ from novel_proofer.workflow import (
     WorkflowInvariantError,
     WorkflowState,
     require_event,
-    validate_job_phase_invariants,
 )
 
 logger = logging.getLogger(__name__)
 
-_JOB_STATE_VERSION = 3
 _JOB_ID_RE = re.compile(r"^[0-9a-f]{32}$", re.IGNORECASE)
 
-_JOB_PHASES = {phase.value for phase in JobPhase}
 _JOB_STATES = {state.value for state in JobState}
 _WAIT_REASONS = {reason.value for reason in WaitReason}
-_CHUNK_STATE_VALUES = {state.value for state in ChunkState}
 _CHUNK_STATES = (
     ChunkState.PENDING,
     ChunkState.PROCESSING,
@@ -132,11 +140,8 @@ class JobStatus:
     cleanup_debug_dir: bool = True
 
 
-_FORMAT_DEFAULTS = FormatConfig()
-
-
 def _new_chunk_counts() -> dict[str, int]:
-    return {s: 0 for s in _CHUNK_STATES}
+    return {state.value: 0 for state in _CHUNK_STATES}
 
 
 def _compute_chunk_counts(chunks: list[ChunkStatus]) -> dict[str, int]:
@@ -146,286 +151,119 @@ def _compute_chunk_counts(chunks: list[ChunkStatus]) -> dict[str, int]:
     return out
 
 
-def _require_dict(raw: object, *, context: str) -> dict[str, Any]:
-    if not isinstance(raw, dict):
-        raise ValueError(f"{context} must be an object")
-    return raw
-
-
-def _reject_unknown_fields(raw: dict[str, Any], allowed: set[str], *, context: str) -> None:
-    extra = sorted(set(raw) - allowed)
-    if extra:
-        raise ValueError(f"{context} contains unknown fields: {', '.join(extra)}")
-
-
-def _require_field(raw: dict[str, Any], key: str, *, context: str) -> Any:
-    if key not in raw:
-        raise ValueError(f"{context} missing field {key!r}")
-    return raw[key]
-
-
-def _parse_int(raw: Any, *, context: str) -> int:
-    if isinstance(raw, bool) or not isinstance(raw, int):
-        raise ValueError(f"{context} must be an integer")
-    return int(raw)
-
-
-def _parse_float(raw: Any, *, context: str) -> float:
-    if isinstance(raw, bool) or not isinstance(raw, int | float):
-        raise ValueError(f"{context} must be a number")
-    return float(raw)
-
-
-def _parse_bool(raw: Any, *, context: str) -> bool:
-    if not isinstance(raw, bool):
-        raise ValueError(f"{context} must be a boolean")
-    return raw
-
-
-def _parse_optional_float(raw: Any, *, context: str) -> float | None:
-    if raw is None:
-        return None
-    return _parse_float(raw, context=context)
-
-
-def _parse_optional_int(raw: Any, *, context: str) -> int | None:
-    if raw is None:
-        return None
-    return _parse_int(raw, context=context)
-
-
-def _parse_non_negative_int(raw: Any, *, context: str) -> int:
-    value = _parse_int(raw, context=context)
-    if value < 0:
-        raise ValueError(f"{context} must be >= 0")
-    return value
-
-
-def _parse_optional_non_negative_int(raw: Any, *, context: str) -> int | None:
-    if raw is None:
-        return None
-    return _parse_non_negative_int(raw, context=context)
-
-
-def _parse_str(raw: Any, *, context: str, allow_empty: bool = True) -> str:
-    if not isinstance(raw, str):
-        raise ValueError(f"{context} must be a string")
-    if not allow_empty and not raw.strip():
-        raise ValueError(f"{context} must not be empty")
-    return raw
-
-
-def _parse_optional_str(raw: Any, *, context: str) -> str | None:
-    if raw is None:
-        return None
-    return _parse_str(raw, context=context)
-
-
-def _parse_enum(raw: Any, *, context: str, allowed: set[str]) -> str:
-    value = _parse_str(raw, context=context, allow_empty=False)
-    if value not in allowed:
-        raise ValueError(f"{context} must be one of {sorted(allowed)!r}")
-    return value
-
-
-def _parse_stats(raw: object) -> dict[str, int]:
-    stats = _require_dict(raw, context="job.stats")
-    out: dict[str, int] = {}
-    for key, value in stats.items():
-        if not isinstance(key, str) or not key:
-            raise ValueError("job.stats keys must be non-empty strings")
-        out[key] = _parse_non_negative_int(value, context=f"job.stats[{key!r}]")
-    return out
-
-
-def _parse_chunk_counts(raw: object, chunks: list[ChunkStatus]) -> dict[str, int]:
-    counts = _require_dict(raw, context="job.chunk_counts")
-    expected = {str(state) for state in _CHUNK_STATES}
-    extra = sorted(set(counts) - expected)
-    if extra:
-        raise ValueError(f"job.chunk_counts contains unknown fields: {', '.join(extra)}")
-    missing = sorted(expected - set(counts))
-    if missing:
-        raise ValueError(f"job.chunk_counts missing fields: {', '.join(missing)}")
-    out = {key: _parse_non_negative_int(value, context=f"job.chunk_counts[{key!r}]") for key, value in counts.items()}
-    computed = _compute_chunk_counts(chunks)
-    if out != computed:
-        raise ValueError("job.chunk_counts does not match chunk_statuses")
-    return out
-
-
-def _format_config_from_dict(raw: object) -> FormatConfig:
-    config = _require_dict(raw, context="job.format")
-    allowed = {f.name for f in fields(FormatConfig)}
-    _reject_unknown_fields(config, allowed, context="job.format")
-    kwargs: dict[str, Any] = {}
-    for f in fields(FormatConfig):
-        value = _require_field(config, f.name, context="job.format")
-        default = getattr(_FORMAT_DEFAULTS, f.name)
-        if isinstance(default, bool):
-            kwargs[f.name] = _parse_bool(value, context=f"job.format.{f.name}")
-            continue
-        if isinstance(default, int):
-            kwargs[f.name] = _parse_int(value, context=f"job.format.{f.name}")
-            continue
-        kwargs[f.name] = value
-    return FormatConfig(**kwargs)
-
-
-def _chunk_to_dict(cs: ChunkStatus) -> dict[str, Any]:
-    return asdict(cs)
-
-
-def _chunk_from_dict(d: dict[str, Any]) -> ChunkStatus:
-    raw = _require_dict(d, context="chunk")
-    _reject_unknown_fields(
-        raw,
-        {
-            "index",
-            "state",
-            "started_at",
-            "finished_at",
-            "retries",
-            "last_error_code",
-            "last_error_message",
-            "llm_model",
-            "input_chars",
-            "output_chars",
-        },
-        context="chunk",
-    )
-    return ChunkStatus(
-        index=_parse_non_negative_int(_require_field(raw, "index", context="chunk"), context="chunk.index"),
-        state=_parse_enum(
-            _require_field(raw, "state", context="chunk"), context="chunk.state", allowed=_CHUNK_STATE_VALUES
-        ),
-        started_at=_parse_optional_float(raw.get("started_at"), context="chunk.started_at"),
-        finished_at=_parse_optional_float(raw.get("finished_at"), context="chunk.finished_at"),
-        retries=_parse_non_negative_int(_require_field(raw, "retries", context="chunk"), context="chunk.retries"),
-        last_error_code=_parse_optional_int(raw.get("last_error_code"), context="chunk.last_error_code"),
-        last_error_message=_parse_optional_str(raw.get("last_error_message"), context="chunk.last_error_message"),
-        llm_model=_parse_optional_str(raw.get("llm_model"), context="chunk.llm_model"),
-        input_chars=_parse_optional_non_negative_int(raw.get("input_chars"), context="chunk.input_chars"),
-        output_chars=_parse_optional_non_negative_int(raw.get("output_chars"), context="chunk.output_chars"),
-    )
-
-
-def _job_to_dict(st: JobStatus) -> dict[str, Any]:
-    return {"version": _JOB_STATE_VERSION, "job": asdict(st)}
-
-
-def _job_from_dict(d: dict[str, Any]) -> JobStatus:
-    payload = _require_dict(d, context="job state file")
-    version = _parse_int(_require_field(payload, "version", context="job state file"), context="job state file.version")
-    if version != _JOB_STATE_VERSION:
-        raise ValueError(f"unsupported job state version {version}; expected {_JOB_STATE_VERSION}")
-
-    job = _require_dict(_require_field(payload, "job", context="job state file"), context="job")
-    _reject_unknown_fields(
-        job,
-        {
-            "job_id",
-            "state",
-            "phase",
-            "wait_reason",
-            "created_at",
-            "started_at",
-            "finished_at",
-            "input_filename",
-            "output_filename",
-            "total_chunks",
-            "done_chunks",
-            "format",
-            "last_error_code",
-            "last_retry_count",
-            "last_llm_model",
-            "stats",
-            "chunk_statuses",
-            "chunk_counts",
-            "error",
-            "output_path",
-            "work_dir",
-            "cleanup_debug_dir",
-        },
-        context="job",
-    )
-
-    chunk_items = _require_field(job, "chunk_statuses", context="job")
-    if not isinstance(chunk_items, list):
-        raise ValueError("job.chunk_statuses must be a list")
-    chunks = [_chunk_from_dict(item) for item in chunk_items]
-    for expected_index, chunk in enumerate(chunks):
-        if chunk.index != expected_index:
-            raise ValueError(
-                f"chunk index mismatch at position {expected_index}: expected {expected_index}, got {chunk.index}"
-            )
-
-    total_chunks = _parse_non_negative_int(
-        _require_field(job, "total_chunks", context="job"), context="job.total_chunks"
-    )
-    done_chunks = _parse_non_negative_int(_require_field(job, "done_chunks", context="job"), context="job.done_chunks")
-    counted_done = sum(1 for chunk in chunks if chunk.state == ChunkState.DONE)
-    if total_chunks != len(chunks):
-        raise ValueError("job.total_chunks does not match chunk_statuses length")
-    if done_chunks != counted_done:
-        raise ValueError("job.done_chunks does not match chunk_statuses")
-
-    state = _parse_enum(_require_field(job, "state", context="job"), context="job.state", allowed=_JOB_STATES)
-    phase = _parse_enum(_require_field(job, "phase", context="job"), context="job.phase", allowed=_JOB_PHASES)
-    wait_reason = _parse_optional_str(job.get("wait_reason"), context="job.wait_reason")
-    if wait_reason is not None and wait_reason not in _WAIT_REASONS:
-        raise ValueError(f"job.wait_reason must be one of {sorted(_WAIT_REASONS)!r}")
-    if state == JobState.PAUSED and wait_reason is None:
-        raise ValueError("job.wait_reason is required when job.state is 'paused'")
-    if state != JobState.PAUSED and wait_reason is not None:
-        raise ValueError("job.wait_reason must be null unless job.state is 'paused'")
-    try:
-        validate_job_phase_invariants(state, phase, [chunk.state for chunk in chunks])
-    except WorkflowInvariantError as e:
-        raise ValueError(str(e)) from e
-
-    job_id = _parse_str(_require_field(job, "job_id", context="job"), context="job.job_id", allow_empty=False)
-    if not _JOB_ID_RE.fullmatch(job_id):
-        raise ValueError("job.job_id must be a 32-character lowercase hex string")
-    chunk_counts = _parse_chunk_counts(_require_field(job, "chunk_counts", context="job"), chunks)
-
-    return JobStatus(
-        job_id=job_id,
+def _chunk_to_record(cs: ChunkStatus) -> ChunkRecord:
+    state = str(cs.state)
+    started_at = cs.started_at
+    finished_at = cs.finished_at
+    if cs.state in {ChunkState.PROCESSING, ChunkState.RETRYING}:
+        state = ChunkState.PENDING.value
+        started_at = None
+        finished_at = None
+    return ChunkRecord(
+        index=cs.index,
         state=state,
-        phase=phase,
-        wait_reason=wait_reason,
-        created_at=_parse_float(_require_field(job, "created_at", context="job"), context="job.created_at"),
-        started_at=_parse_optional_float(job.get("started_at"), context="job.started_at"),
-        finished_at=_parse_optional_float(job.get("finished_at"), context="job.finished_at"),
-        input_filename=_parse_str(
-            _require_field(job, "input_filename", context="job"),
-            context="job.input_filename",
-            allow_empty=False,
+        started_at=started_at,
+        finished_at=finished_at,
+        retries=cs.retries,
+        last_error_code=cs.last_error_code,
+        last_error_message=cs.last_error_message,
+        llm_model=cs.llm_model,
+        input_chars=cs.input_chars,
+        output_chars=cs.output_chars,
+    )
+
+
+def _chunk_from_record(record: ChunkRecord) -> ChunkStatus:
+    return ChunkStatus(
+        index=record.index,
+        state=record.state,
+        started_at=record.started_at,
+        finished_at=record.finished_at,
+        retries=record.retries,
+        last_error_code=record.last_error_code,
+        last_error_message=record.last_error_message,
+        llm_model=record.llm_model,
+        input_chars=record.input_chars,
+        output_chars=record.output_chars,
+    )
+
+
+def _durable_workflow_for_snapshot(st: JobStatus) -> WorkflowRecord:
+    if st.state in {JobState.QUEUED, JobState.RUNNING}:
+        return WorkflowRecord(
+            state=JobState.PAUSED.value,
+            phase=str(st.phase),
+            wait_reason=WaitReason.SERVER_RECOVERED.value,
+        )
+    return WorkflowRecord(
+        state=str(st.state),
+        phase=str(st.phase),
+        wait_reason=None if st.wait_reason is None else str(st.wait_reason),
+    )
+
+
+def _job_to_record(st: JobStatus) -> JobRecord:
+    chunks = [_chunk_to_record(chunk) for chunk in st.chunk_statuses]
+    chunk_counts = _compute_chunk_counts([_chunk_from_record(chunk) for chunk in chunks])
+    return JobRecord(
+        job_id=st.job_id,
+        workflow=_durable_workflow_for_snapshot(st),
+        timestamps=TimestampRecord(
+            created_at=st.created_at,
+            started_at=st.started_at,
+            finished_at=st.finished_at,
         ),
-        output_filename=_parse_str(
-            _require_field(job, "output_filename", context="job"),
-            context="job.output_filename",
-            allow_empty=False,
+        artifacts=ArtifactRecord(
+            input_filename=st.input_filename,
+            output_filename=st.output_filename,
+            output_path=st.output_path,
+            work_dir=st.work_dir,
+            cleanup_debug_dir=st.cleanup_debug_dir,
         ),
-        total_chunks=total_chunks,
-        done_chunks=done_chunks,
-        format=_format_config_from_dict(_require_field(job, "format", context="job")),
-        last_error_code=_parse_optional_int(job.get("last_error_code"), context="job.last_error_code"),
-        last_retry_count=_parse_non_negative_int(
-            _require_field(job, "last_retry_count", context="job"),
-            context="job.last_retry_count",
+        format=st.format,
+        llm=LLMRecord(
+            last_error_code=st.last_error_code,
+            last_retry_count=st.last_retry_count,
+            last_llm_model=st.last_llm_model,
         ),
-        last_llm_model=_parse_optional_str(job.get("last_llm_model"), context="job.last_llm_model"),
-        stats=_parse_stats(_require_field(job, "stats", context="job")),
+        chunks=ChunkSetRecord(
+            total=len(chunks),
+            done=sum(1 for chunk in chunks if chunk.state == ChunkState.DONE),
+            counts=chunk_counts,
+            items=chunks,
+        ),
+        diagnostics=DiagnosticsRecord(
+            stats=dict(st.stats),
+            error=st.error,
+        ),
+    )
+
+
+def _job_from_record(record: JobRecord) -> JobStatus:
+    chunks = [_chunk_from_record(chunk) for chunk in record.chunks.items]
+    return JobStatus(
+        job_id=record.job_id,
+        state=record.workflow.state,
+        phase=record.workflow.phase,
+        wait_reason=record.workflow.wait_reason,
+        created_at=record.timestamps.created_at,
+        started_at=record.timestamps.started_at,
+        finished_at=record.timestamps.finished_at,
+        input_filename=record.artifacts.input_filename,
+        output_filename=record.artifacts.output_filename,
+        total_chunks=record.chunks.total,
+        done_chunks=record.chunks.done,
+        format=record.format,
+        last_error_code=record.llm.last_error_code,
+        last_retry_count=record.llm.last_retry_count,
+        last_llm_model=record.llm.last_llm_model,
+        stats=dict(record.diagnostics.stats),
         chunk_statuses=chunks,
-        chunk_counts=chunk_counts,
-        error=_parse_optional_str(job.get("error"), context="job.error"),
-        output_path=_parse_optional_str(job.get("output_path"), context="job.output_path"),
-        work_dir=_parse_optional_str(job.get("work_dir"), context="job.work_dir"),
-        cleanup_debug_dir=_parse_bool(
-            _require_field(job, "cleanup_debug_dir", context="job"),
-            context="job.cleanup_debug_dir",
-        ),
+        chunk_counts=dict(record.chunks.counts),
+        error=record.diagnostics.error,
+        output_path=record.artifacts.output_path,
+        work_dir=record.artifacts.work_dir,
+        cleanup_debug_dir=record.artifacts.cleanup_debug_dir,
     )
 
 
@@ -504,16 +342,16 @@ class JobStore:
             try:
                 tmp.unlink(missing_ok=True)
             except Exception:
-                logger.exception("failed to cleanup temp job state file: %s", tmp)
+                logger.exception("failed to cleanup temp job record file: %s", tmp)
 
     def _persist_snapshot_unlocked(self, snapshot: JobStatus) -> None:
         path = self._persist_path_for_job_id(snapshot.job_id)
         if path is None:
             return
         try:
-            self._atomic_write_json(path, _job_to_dict(snapshot))
+            self._atomic_write_json(path, job_record_to_payload(_job_to_record(snapshot)))
         except Exception:
-            logger.exception("failed to persist job state: job_id=%s", snapshot.job_id)
+            logger.exception("failed to persist job record: job_id=%s", snapshot.job_id)
 
     def _persist_snapshot_direct(self, snapshot: JobStatus) -> None:
         with self._persist_lock:
@@ -573,7 +411,7 @@ class JobStore:
                 try:
                     self._flush_job(jid, require_dirty=True)
                 except Exception:
-                    logger.exception("failed to flush dirty job state: job_id=%s", jid)
+                    logger.exception("failed to flush dirty job record: job_id=%s", jid)
 
     def _flush_job(self, job_id: str, *, require_dirty: bool) -> None:
         if self._persist_dir is None:
@@ -664,10 +502,12 @@ class JobStore:
         for p in sorted(persist_dir.glob("*.json")):
             try:
                 obj = json.loads(p.read_text(encoding="utf-8"))
-                st, needs_rewrite = self._restore_loaded_job_after_restart(_job_from_dict(obj))
+                st, needs_rewrite = self._restore_loaded_job_after_restart(
+                    _job_from_record(job_record_from_payload(obj))
+                )
             except Exception as e:
                 raise ValueError(
-                    f"failed to load persisted job state {p}; delete the corrupted state file and retry"
+                    f"failed to load persisted job record {p}; delete the corrupted state file and retry"
                 ) from e
             loaded.append((st, needs_rewrite))
 
@@ -992,7 +832,7 @@ class JobStore:
                 if path.exists():
                     path.unlink()
             except Exception:
-                logger.exception("failed to delete persisted job state: job_id=%s", job_id)
+                logger.exception("failed to delete persisted job record: job_id=%s", job_id)
             return existed
 
     def is_cancelled(self, job_id: str) -> bool:

--- a/novel_proofer/jobs.py
+++ b/novel_proofer/jobs.py
@@ -23,6 +23,7 @@ from novel_proofer.job_records import (
     LLMRecord,
     TimestampRecord,
     WorkflowRecord,
+    compute_chunk_counts,
     job_record_from_payload,
     job_record_to_payload,
 )
@@ -204,7 +205,7 @@ def _durable_workflow_for_snapshot(st: JobStatus) -> WorkflowRecord:
 
 def _job_to_record(st: JobStatus) -> JobRecord:
     chunks = [_chunk_to_record(chunk) for chunk in st.chunk_statuses]
-    chunk_counts = _compute_chunk_counts([_chunk_from_record(chunk) for chunk in chunks])
+    chunk_counts = compute_chunk_counts(chunks)
     return JobRecord(
         job_id=st.job_id,
         workflow=_durable_workflow_for_snapshot(st),

--- a/tests/jobs/test_store.py
+++ b/tests/jobs/test_store.py
@@ -8,47 +8,98 @@ from typing import Any
 import pytest
 
 from novel_proofer.formatting.config import FormatConfig
-from novel_proofer.jobs import JobStore, _job_from_dict
+from novel_proofer.job_records import JOB_RECORD_VERSION, job_record_from_payload
+from novel_proofer.jobs import JobStore
 from novel_proofer.states import ChunkState, JobPhase, JobState, WaitReason
 
 
-def _raw_job_snapshot(
+def _chunk_item(
     *,
+    index: int = 0,
+    state: ChunkState | str = ChunkState.PENDING,
+    started_at: float | None = None,
+    finished_at: float | None = None,
+    retries: int = 0,
+    last_error_code: int | None = None,
+    last_error_message: str | None = None,
+    llm_model: str | None = None,
+    input_chars: int | None = None,
+    output_chars: int | None = None,
+) -> dict[str, Any]:
+    return {
+        "index": index,
+        "state": state,
+        "started_at": started_at,
+        "finished_at": finished_at,
+        "retries": retries,
+        "last_error_code": last_error_code,
+        "last_error_message": last_error_message,
+        "llm_model": llm_model,
+        "input_chars": input_chars,
+        "output_chars": output_chars,
+    }
+
+
+def _chunk_counts(chunks: list[dict[str, Any]]) -> dict[str, int]:
+    counts = {
+        "pending": 0,
+        "processing": 0,
+        "retrying": 0,
+        "done": 0,
+        "error": 0,
+    }
+    for chunk in chunks:
+        state = str(chunk["state"])
+        counts[state] += 1
+    return counts
+
+
+def _raw_job_record(
+    *,
+    job_id: str = "a" * 32,
     state: JobState | str = JobState.PAUSED,
     phase: JobPhase | str = JobPhase.PROCESS,
     wait_reason: WaitReason | str | None = WaitReason.USER_PAUSED,
+    chunks: list[dict[str, Any]] | None = None,
 ) -> dict[str, Any]:
+    chunk_items = [] if chunks is None else chunks
     return {
-        "version": 3,
-        "job": {
-            "job_id": "a" * 32,
-            "state": state,
-            "phase": phase,
-            "wait_reason": wait_reason,
-            "created_at": 1.0,
-            "started_at": None,
-            "finished_at": None,
-            "input_filename": "in.txt",
-            "output_filename": "out.txt",
-            "total_chunks": 0,
-            "done_chunks": 0,
-            "format": json.loads(json.dumps(FormatConfig().__dict__)),
-            "last_error_code": None,
-            "last_retry_count": 0,
-            "last_llm_model": None,
-            "stats": {},
-            "chunk_statuses": [],
-            "chunk_counts": {
-                "pending": 0,
-                "processing": 0,
-                "retrying": 0,
-                "done": 0,
-                "error": 0,
+        "version": JOB_RECORD_VERSION,
+        "job_record": {
+            "job_id": job_id,
+            "workflow": {
+                "state": state,
+                "phase": phase,
+                "wait_reason": wait_reason,
             },
-            "error": None,
-            "output_path": None,
-            "work_dir": None,
-            "cleanup_debug_dir": True,
+            "timestamps": {
+                "created_at": 1.0,
+                "started_at": None,
+                "finished_at": None,
+            },
+            "artifacts": {
+                "input_filename": "in.txt",
+                "output_filename": "out.txt",
+                "output_path": None,
+                "work_dir": None,
+                "cleanup_debug_dir": True,
+            },
+            "format": json.loads(json.dumps(FormatConfig().__dict__)),
+            "llm": {
+                "last_error_code": None,
+                "last_retry_count": 0,
+                "last_llm_model": None,
+            },
+            "chunks": {
+                "total": len(chunk_items),
+                "done": sum(1 for chunk in chunk_items if str(chunk["state"]) == ChunkState.DONE.value),
+                "counts": _chunk_counts(chunk_items),
+                "items": chunk_items,
+            },
+            "diagnostics": {
+                "stats": {},
+                "error": None,
+            },
         },
     }
 
@@ -277,78 +328,141 @@ def test_job_store_persistence_is_throttled_and_flushable(tmp_path: Path) -> Non
         js.shutdown_persistence(wait=True)
 
 
-def test_job_from_dict_rejects_missing_phase() -> None:
-    raw = _raw_job_snapshot()
-    del raw["job"]["phase"]
+def test_job_record_rejects_missing_phase() -> None:
+    raw = _raw_job_record()
+    del raw["job_record"]["workflow"]["phase"]
 
     with pytest.raises(ValueError, match="missing field 'phase'"):
-        _job_from_dict(raw)
+        job_record_from_payload(raw)
 
 
-def test_job_from_dict_rejects_paused_without_wait_reason() -> None:
-    raw = _raw_job_snapshot(wait_reason=None)
+def test_job_record_rejects_unknown_root_fields() -> None:
+    raw = _raw_job_record()
+    raw["job"] = {}
 
-    with pytest.raises(ValueError, match="wait_reason is required"):
-        _job_from_dict(raw)
-
-
-def test_job_from_dict_rejects_non_paused_with_wait_reason() -> None:
-    raw = _raw_job_snapshot(state=JobState.RUNNING, phase=JobPhase.VALIDATE, wait_reason=WaitReason.USER_PAUSED)
-
-    with pytest.raises(ValueError, match="wait_reason must be null"):
-        _job_from_dict(raw)
+    with pytest.raises(ValueError, match="job record file contains unknown fields: job"):
+        job_record_from_payload(raw)
 
 
-def test_job_store_load_persisted_jobs_rejects_corrupt_snapshot(tmp_path: Path) -> None:
-    bad = tmp_path / f"{'a' * 32}.json"
+def test_job_record_rejects_paused_without_wait_reason() -> None:
+    raw = _raw_job_record(wait_reason=None)
+
+    with pytest.raises(ValueError, match="paused workflow state requires wait_reason"):
+        job_record_from_payload(raw)
+
+
+def test_job_record_rejects_non_paused_with_wait_reason() -> None:
+    raw = _raw_job_record(state=JobState.RUNNING, phase=JobPhase.VALIDATE, wait_reason=WaitReason.USER_PAUSED)
+
+    with pytest.raises(ValueError, match="workflow wait_reason must be None"):
+        job_record_from_payload(raw)
+
+
+def test_job_store_persists_job_record_without_volatile_execution(tmp_path: Path) -> None:
+    js = JobStore(persist_interval_s=60.0)
+    js.configure_persistence(persist_dir=tmp_path)
+    try:
+        st = js.create("in.txt", "out.txt", total_chunks=1)
+        job_id = st.job_id
+        js.init_chunks(job_id, total_chunks=1)
+        js.update(job_id, state=JobState.RUNNING, phase=JobPhase.PROCESS, started_at=2.0)
+        js.update_chunk(job_id, 0, state=ChunkState.PROCESSING, started_at=3.0, input_chars=10)
+
+        runtime = js.get(job_id)
+        assert runtime is not None
+        assert runtime.state == JobState.RUNNING
+        assert runtime.chunk_statuses[0].state == ChunkState.PROCESSING
+
+        js.flush_persistence(job_id)
+        payload = json.loads((tmp_path / f"{job_id}.json").read_text(encoding="utf-8"))
+
+        assert payload["version"] == JOB_RECORD_VERSION
+        assert "job" not in payload
+        record = payload["job_record"]
+        assert record["workflow"] == {
+            "state": JobState.PAUSED,
+            "phase": JobPhase.PROCESS,
+            "wait_reason": WaitReason.SERVER_RECOVERED,
+        }
+        assert record["chunks"]["counts"]["pending"] == 1
+        assert record["chunks"]["counts"]["processing"] == 0
+        assert record["chunks"]["items"][0]["state"] == ChunkState.PENDING
+        assert record["chunks"]["items"][0]["started_at"] is None
+        assert record["chunks"]["items"][0]["input_chars"] == 10
+        job_record_from_payload(payload)
+    finally:
+        js.shutdown_persistence(wait=True)
+
+
+def test_job_store_load_persisted_jobs_loads_clean_record(tmp_path: Path) -> None:
+    job_id = "b" * 32
+    snap = tmp_path / f"{job_id}.json"
+    snap.write_text(
+        json.dumps(
+            _raw_job_record(
+                job_id=job_id,
+                state=JobState.PAUSED,
+                phase=JobPhase.PROCESS,
+                wait_reason=WaitReason.READY_TO_PROCESS,
+                chunks=[_chunk_item(index=0, state=ChunkState.PENDING)],
+            )
+        ),
+        encoding="utf-8",
+    )
+
+    js = JobStore()
+    js.configure_persistence(persist_dir=tmp_path)
+    try:
+        assert js.load_persisted_jobs() == 1
+        loaded = js.get(job_id)
+        assert loaded is not None
+        assert loaded.state == JobState.PAUSED
+        assert loaded.phase == JobPhase.PROCESS
+        assert loaded.wait_reason == WaitReason.READY_TO_PROCESS
+        assert loaded.chunk_counts == _chunk_counts([_chunk_item(index=0, state=ChunkState.PENDING)])
+    finally:
+        js.shutdown_persistence(wait=True)
+
+
+def test_job_store_load_persisted_jobs_preserves_server_recovered_record(tmp_path: Path) -> None:
+    job_id = "c" * 32
+    snap = tmp_path / f"{job_id}.json"
+    snap.write_text(
+        json.dumps(
+            _raw_job_record(
+                job_id=job_id,
+                state=JobState.PAUSED,
+                phase=JobPhase.VALIDATE,
+                wait_reason=WaitReason.SERVER_RECOVERED,
+            )
+        ),
+        encoding="utf-8",
+    )
+
+    js = JobStore()
+    js.configure_persistence(persist_dir=tmp_path)
+    try:
+        assert js.load_persisted_jobs() == 1
+        loaded = js.get(job_id)
+        assert loaded is not None
+        assert loaded.state == JobState.PAUSED
+        assert loaded.phase == JobPhase.VALIDATE
+        assert loaded.wait_reason == WaitReason.SERVER_RECOVERED
+    finally:
+        js.shutdown_persistence(wait=True)
+
+
+def test_job_store_load_persisted_jobs_rejects_corrupt_record(tmp_path: Path) -> None:
+    bad = tmp_path / f"{'d' * 32}.json"
     bad.write_text(
         json.dumps(
-            {
-                "version": 3,
-                "job": {
-                    "job_id": "a" * 32,
-                    "state": JobState.PAUSED,
-                    "phase": JobPhase.MERGE,
-                    "wait_reason": WaitReason.READY_TO_MERGE,
-                    "created_at": 1.0,
-                    "started_at": None,
-                    "finished_at": None,
-                    "input_filename": "in.txt",
-                    "output_filename": "out.txt",
-                    "total_chunks": 1,
-                    "done_chunks": 0,
-                    "format": FormatConfig().__dict__,
-                    "last_error_code": None,
-                    "last_retry_count": 0,
-                    "last_llm_model": None,
-                    "stats": {},
-                    "chunk_statuses": [
-                        {
-                            "index": 0,
-                            "state": ChunkState.PENDING,
-                            "started_at": None,
-                            "finished_at": None,
-                            "retries": 0,
-                            "last_error_code": None,
-                            "last_error_message": None,
-                            "llm_model": None,
-                            "input_chars": None,
-                            "output_chars": None,
-                        }
-                    ],
-                    "chunk_counts": {
-                        "pending": 1,
-                        "processing": 0,
-                        "retrying": 0,
-                        "done": 0,
-                        "error": 0,
-                    },
-                    "error": None,
-                    "output_path": None,
-                    "work_dir": None,
-                    "cleanup_debug_dir": True,
-                },
-            }
+            _raw_job_record(
+                job_id="d" * 32,
+                state=JobState.PAUSED,
+                phase=JobPhase.MERGE,
+                wait_reason=WaitReason.READY_TO_MERGE,
+                chunks=[_chunk_item(index=0, state=ChunkState.PENDING)],
+            )
         ),
         encoding="utf-8",
     )
@@ -363,56 +477,18 @@ def test_job_store_load_persisted_jobs_rejects_corrupt_snapshot(tmp_path: Path) 
         js.shutdown_persistence(wait=True)
 
 
-def test_job_store_load_persisted_jobs_restores_running_job_as_paused(tmp_path: Path) -> None:
-    snap = tmp_path / f"{'b' * 32}.json"
+def test_job_store_load_persisted_jobs_restores_in_flight_record_as_paused(tmp_path: Path) -> None:
+    job_id = "e" * 32
+    snap = tmp_path / f"{job_id}.json"
     snap.write_text(
         json.dumps(
-            {
-                "version": 3,
-                "job": {
-                    "job_id": "b" * 32,
-                    "state": JobState.RUNNING,
-                    "phase": JobPhase.PROCESS,
-                    "wait_reason": None,
-                    "created_at": 1.0,
-                    "started_at": 2.0,
-                    "finished_at": None,
-                    "input_filename": "in.txt",
-                    "output_filename": "out.txt",
-                    "total_chunks": 1,
-                    "done_chunks": 0,
-                    "format": FormatConfig().__dict__,
-                    "last_error_code": None,
-                    "last_retry_count": 0,
-                    "last_llm_model": None,
-                    "stats": {},
-                    "chunk_statuses": [
-                        {
-                            "index": 0,
-                            "state": ChunkState.PROCESSING,
-                            "started_at": 3.0,
-                            "finished_at": None,
-                            "retries": 0,
-                            "last_error_code": None,
-                            "last_error_message": None,
-                            "llm_model": None,
-                            "input_chars": 10,
-                            "output_chars": None,
-                        }
-                    ],
-                    "chunk_counts": {
-                        "pending": 0,
-                        "processing": 1,
-                        "retrying": 0,
-                        "done": 0,
-                        "error": 0,
-                    },
-                    "error": None,
-                    "output_path": None,
-                    "work_dir": None,
-                    "cleanup_debug_dir": True,
-                },
-            }
+            _raw_job_record(
+                job_id=job_id,
+                state=JobState.RUNNING,
+                phase=JobPhase.PROCESS,
+                wait_reason=None,
+                chunks=[_chunk_item(index=0, state=ChunkState.PROCESSING, started_at=3.0, input_chars=10)],
+            )
         ),
         encoding="utf-8",
     )
@@ -421,7 +497,7 @@ def test_job_store_load_persisted_jobs_restores_running_job_as_paused(tmp_path: 
     js.configure_persistence(persist_dir=tmp_path)
     try:
         assert js.load_persisted_jobs() == 1
-        loaded = js.get("b" * 32)
+        loaded = js.get(job_id)
         assert loaded is not None
         assert loaded.state == JobState.PAUSED
         assert loaded.phase == JobPhase.PROCESS

--- a/tests/jobs/test_store.py
+++ b/tests/jobs/test_store.py
@@ -344,6 +344,14 @@ def test_job_record_rejects_unknown_root_fields() -> None:
         job_record_from_payload(raw)
 
 
+def test_job_record_rejects_mismatched_chunk_counts() -> None:
+    raw = _raw_job_record(chunks=[_chunk_item(index=0, state=ChunkState.PENDING)])
+    raw["job_record"]["chunks"]["counts"]["pending"] = 0
+
+    with pytest.raises(ValueError, match="job_record\\.chunks\\.counts does not match chunk items"):
+        job_record_from_payload(raw)
+
+
 def test_job_record_rejects_paused_without_wait_reason() -> None:
     raw = _raw_job_record(wait_reason=None)
 


### PR DESCRIPTION
## Summary

- introduce a strict v4 JobRecord persistence schema under `novel_proofer.job_records`
- convert runtime `JobStatus` to durable records at the persistence boundary
- avoid persisting volatile execution truth: active jobs become `paused/server_recovered`, active chunks become `pending`
- keep restart loading strict and explicit, with tests for clean, in-flight, server-recovered, and invalid records

Closes #79

## Validation

- `uv run --frozen --no-sync ruff format --check`
- `uv run --frozen --no-sync ruff check`
- `uv run --frozen --no-sync python -m mypy novel_proofer`
- `uv run --frozen --no-sync python -m pytest -q -m 'not llm_integration'` -> 193 passed, 5 deselected, coverage 83.50%
- `uv run --frozen --no-sync python tools/export-openapi.py --check`
- `uv run --frozen --no-sync python tools/check-large-files.py`

## Summary by Sourcery

Introduce a strict, versioned JobRecord persistence schema and update job storage to read and write this durable format while treating in-flight execution state as non-persistent.

Enhancements:
- Extract job persistence into a dedicated job_records module with explicit dataclasses and schema validation for workflow, timestamps, artifacts, LLM metadata, chunks, and diagnostics.
- Update JobStore to convert between runtime JobStatus and JobRecord, normalizing active jobs to paused/server_recovered and active chunks to pending when persisting.
- Tighten logging messages and error wording around job record persistence, loading, and deletion to reflect the new durable record model.

Documentation:
- Document the new job_records module and add workflow persistence test cases to ARCHITECTURE and TESTCASES.

Tests:
- Add focused tests covering JobRecord schema validation, round-tripping, and JobStore behavior when persisting and reloading clean, in-flight, server-recovered, and corrupt job records.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 发布说明

* **功能改进**
  * 优化作业记录的持久化和恢复机制，提升数据完整性和可靠性。
  * 加强作业状态的校验与容错能力，确保中断后能更准确地恢复执行进度。

* **测试**
  * 扩大作业持久化和恢复场景的测试覆盖范围。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->