### PR TITLE
refactor(ui): make job attachment explicit

### DIFF
--- a/docs/TESTCASES.md
+++ b/docs/TESTCASES.md
@@ -28,11 +28,19 @@
 | `tests/api/test_endpoints.py::test_rerun_all_creates_new_job_without_reupload` | 覆盖 `POST /api/v1/jobs/{job_id}/rerun-all`：基于输入缓存创建新任务并从头跑完整流程，且不需要重新上传文件。 |
 | `tests/api/test_endpoints.py::test_job_input_stats_endpoint` | 覆盖 `GET /api/v1/jobs/{job_id}/input-stats`：基于输入缓存统计“非空白字符数”（UI 字数口径）。 |
 
+## tests/api/test_attachment_js.py
+
+| Test case | 说明 |
+| --- | --- |
+| `tests/api/test_attachment_js.py::test_ui_attachment_helpers_are_browser_local_only` | 覆盖浏览器侧 `UiAttachment` helper：job id 归一化、localStorage 持久化、恢复、清除，以及空 job id 的显式错误。 |
+
 ## tests/api/test_lifecycle_js.py
 
 | Test case | 说明 |
 | --- | --- |
 | `tests/api/test_lifecycle_js.py::test_browser_lifecycle_handlers_do_not_mutate_jobs` | 验证浏览器 `pagehide/beforeunload` 生命周期只停止本地 UI observer，不会在页面卸载时调用任何后端任务变更逻辑；从 bfcache `pageshow` 返回时只重新拉取快照恢复 observer。 |
+| `tests/api/test_lifecycle_js.py::test_restore_and_missing_job_only_change_ui_attachment` | 验证页面启动恢复只读取浏览器侧 attachment 并重新 attach；已删除/不存在任务只清 UI attachment，不触发 pause/reset。 |
+| `tests/api/test_lifecycle_js.py::test_new_task_detaches_without_backend_mutation` | 验证“新任务”按钮只解除 UI attachment 与本地文件选择，不调用 pause/reset/purge 等后端任务变更。 |
 
 ## tests/formatting/test_chunking.py
 

--- a/templates/static/js/attachment.js
+++ b/templates/static/js/attachment.js
@@ -1,0 +1,23 @@
+// Browser-side job attachment helpers.
+
+export const ATTACHED_JOB_KEY = 'novel_proofer.attached_job_id.v2';
+
+export function normalizeAttachedJobId(value) {
+    return String(value || '').trim();
+}
+
+export function readPersistedAttachment(storage) {
+    const jobId = normalizeAttachedJobId(storage.getItem(ATTACHED_JOB_KEY));
+    return jobId || null;
+}
+
+export function persistAttachment(storage, jobId) {
+    const normalized = normalizeAttachedJobId(jobId);
+    if (!normalized) throw new Error('missing job_id');
+    storage.setItem(ATTACHED_JOB_KEY, normalized);
+    return normalized;
+}
+
+export function clearPersistedAttachment(storage) {
+    storage.removeItem(ATTACHED_JOB_KEY);
+}

--- a/templates/static/js/main.js
+++ b/templates/static/js/main.js
@@ -2,8 +2,12 @@ import {
     state,
     loadUiState,
     saveUiState,
-    getAttachedJobId,
-    setAttachedJobId,
+    attachedJobId,
+    attachUiToJob,
+    attachmentMatches,
+    detachUiFromJob,
+    hasUiAttachment,
+    restoreUiAttachment,
     UI_STATE_FIELDS,
     getSavedActiveTab,
     saveActiveTab
@@ -29,7 +33,7 @@ async function ensureJobInputChars(jobId) {
         if (!res.ok) {
             const marker = (res.status === 404) ? state.INPUT_CHARS_MISSING : state.INPUT_CHARS_ERROR;
             state.inputCharsCache.set(jid, marker);
-            if (state.currentJobId === jid && ui.elements.fileWordCount) {
+            if (attachmentMatches(jid) && ui.elements.fileWordCount) {
                 ui.elements.fileWordCount.textContent = (marker === state.INPUT_CHARS_MISSING) ? '-' : '读取失败';
             }
             return;
@@ -38,7 +42,7 @@ async function ensureJobInputChars(jobId) {
         const n = Number(res.data?.input_chars);
         if (!Number.isFinite(n) || n < 0) {
             state.inputCharsCache.set(jid, state.INPUT_CHARS_ERROR);
-            if (state.currentJobId === jid && ui.elements.fileWordCount) {
+            if (attachmentMatches(jid) && ui.elements.fileWordCount) {
                 ui.elements.fileWordCount.textContent = '读取失败';
             }
             return;
@@ -46,12 +50,12 @@ async function ensureJobInputChars(jobId) {
 
         const count = Math.floor(n);
         state.inputCharsCache.set(jid, count);
-        if (state.currentJobId === jid && ui.elements.fileWordCount) {
+        if (attachmentMatches(jid) && ui.elements.fileWordCount) {
             ui.elements.fileWordCount.textContent = count.toLocaleString();
         }
     } catch (e) {
         state.inputCharsCache.set(jid, state.INPUT_CHARS_ERROR);
-        if (state.currentJobId === jid && ui.elements.fileWordCount) {
+        if (attachmentMatches(jid) && ui.elements.fileWordCount) {
             ui.elements.fileWordCount.textContent = '读取失败';
         }
     } finally {
@@ -128,9 +132,8 @@ function detachUi({ clearFile = true } = {}) {
     stopPolling();
     state.pollInFlight = false;
 
-    state.currentJobId = null;
+    detachUiFromJob();
     clearCurrentJobSnapshot();
-    setAttachedJobId(null);
 
     state.chunksData = [];
     state.chunkCounts = null;
@@ -153,12 +156,12 @@ function detachUi({ clearFile = true } = {}) {
 }
 
 async function refreshJobOnce(jobId) {
-    if (!jobId || state.currentJobId !== jobId) return;
+    if (!jobId || !attachmentMatches(jobId)) return;
     if (state.pollInFlight) return;
     state.pollInFlight = true;
     try {
         const r = await api.fetchJobSummary(jobId);
-        if (!jobId || state.currentJobId !== jobId) return;
+        if (!jobId || !attachmentMatches(jobId)) return;
         if (!r.ok) {
             if (r.status === 404) {
                 detachUi();
@@ -250,14 +253,13 @@ async function refreshJobOnce(jobId) {
 async function attachJob(jobId) {
     const jid = String(jobId || '').trim();
     if (!jid) return;
-    const switchingJob = state.currentJobId !== jid;
+    const switchingJob = !attachmentMatches(jid);
     if (switchingJob) {
         stopPolling();
         state.pollInFlight = false;
         clearCurrentJobSnapshot();
     }
-    state.currentJobId = jid;
-    setAttachedJobId(jid);
+    attachUiToJob(jid);
 
     state.chunksData = [];
     state.chunkCounts = null;
@@ -402,7 +404,7 @@ function bindUiStateInputs() {
 function bindFileInputEvents() {
     ui.elements.fileInput?.addEventListener('change', () => {
         ui.refreshFileName();
-        if (!state.currentJobId) ui.refreshActionButtons(null);
+        if (!hasUiAttachment()) ui.refreshActionButtons(null);
     });
 
     if (ui.elements.fileInput && ui.elements.fileDrop) {
@@ -418,7 +420,7 @@ function bindFileInputEvents() {
             rmDrag();
             setTimeout(() => {
                 ui.refreshFileName();
-                if (!state.currentJobId) ui.refreshActionButtons(null);
+                if (!hasUiAttachment()) ui.refreshActionButtons(null);
             }, 0);
         });
     }
@@ -429,8 +431,9 @@ function bindTabAndFilterEvents() {
         btn.addEventListener('click', () => {
             ui.switchTab(btn.dataset.tab, () => {
                 saveActiveTab(btn.dataset.tab);
-                if (btn.dataset.tab === 'debug' && state.currentJobId) {
-                    refreshChunksNow(state.currentJobId, { force: true });
+                const jobId = attachedJobId();
+                if (btn.dataset.tab === 'debug' && jobId) {
+                    refreshChunksNow(jobId, { force: true });
                 }
             });
         });
@@ -442,8 +445,9 @@ function bindTabAndFilterEvents() {
         btn.addEventListener('click', () => {
             state.currentFilter = btn.dataset.filter;
             ui.elements.filterBtns.forEach(b => b.classList.toggle('active', b === btn));
-            if (state.activeTab === 'debug' && state.currentJobId) {
-                refreshChunksNow(state.currentJobId, { force: true });
+            const jobId = attachedJobId();
+            if (state.activeTab === 'debug' && jobId) {
+                refreshChunksNow(jobId, { force: true });
             } else {
                 ui.renderChunksTable();
             }
@@ -506,7 +510,7 @@ function bindLlmSettingsEvents() {
 
 function bindJobActionEvents() {
     ui.elements.btnPause?.addEventListener('click', async () => {
-        const jobId = state.currentJobId;
+        const jobId = attachedJobId();
         if (!jobId) return;
         ui.elements.btnPause.disabled = true;
         ui.elements.btnPause.classList.add('opacity-50', 'cursor-not-allowed');
@@ -522,7 +526,7 @@ function bindJobActionEvents() {
     });
 
     ui.elements.btnRetry?.addEventListener('click', async () => {
-        const jobId = state.currentJobId;
+        const jobId = attachedJobId();
         if (!jobId) return;
         ui.show('准备重试失败分片…');
 
@@ -537,7 +541,7 @@ function bindJobActionEvents() {
     });
 
     ui.elements.btnProcess?.addEventListener('click', async () => {
-        const jobId = state.currentJobId;
+        const jobId = attachedJobId();
         if (!jobId) return;
         ui.show('开始校对…');
 
@@ -552,7 +556,7 @@ function bindJobActionEvents() {
     });
 
     ui.elements.btnMerge?.addEventListener('click', async () => {
-        const jobId = state.currentJobId;
+        const jobId = attachedJobId();
         if (!jobId) return;
         ui.show('开始合并输出…');
 
@@ -565,16 +569,16 @@ function bindJobActionEvents() {
     });
 
     ui.elements.btnDownload?.addEventListener('click', () => {
-        api.downloadJobOutput(state.currentJobId);
+        api.downloadJobOutput(attachedJobId());
     });
 
     ui.elements.btnValidate?.addEventListener('click', async () => {
-        if (!state.currentJobId) {
+        if (!hasUiAttachment()) {
             ui.elements.form.requestSubmit();
             return;
         }
         if (state.currentJobCommands.includes('validate')) {
-            const jobId = state.currentJobId;
+            const jobId = attachedJobId();
             ui.show('继续预处理…');
 
             const fd = new FormData(ui.elements.form);
@@ -589,7 +593,7 @@ function bindJobActionEvents() {
     });
 
     ui.elements.btnCancel?.addEventListener('click', async () => {
-        const jobId = state.currentJobId;
+        const jobId = attachedJobId();
         if (!jobId) return;
         const execution = String(state.currentJobExecutionState || '').toLowerCase();
         const phase = String(state.currentJobWorkflowPhase || '').toLowerCase();
@@ -604,7 +608,7 @@ function bindJobActionEvents() {
     });
 
     ui.elements.btnReset?.addEventListener('click', async () => {
-        const jobId = state.currentJobId;
+        const jobId = attachedJobId();
         if (!jobId) return;
         const execution = String(state.currentJobExecutionState || '').toLowerCase();
         const phase = String(state.currentJobWorkflowPhase || '').toLowerCase();
@@ -641,9 +645,10 @@ function bindJobActionEvents() {
         const r = await api.fetchJobList();
         if (!r.ok) { ui.show(r.error); return; }
         const allJobs = Array.isArray(r?.data?.jobs) ? r.data.jobs : [];
-        const hasCurrentJob = !!state.currentJobId;
+        const currentAttachedJobId = attachedJobId();
+        const hasCurrentJob = !!currentAttachedJobId;
         const jobs = hasCurrentJob
-            ? allJobs.filter(j => j?.id !== state.currentJobId)
+            ? allJobs.filter(j => j?.id !== currentAttachedJobId)
             : allJobs;
         if (!jobs.length) {
             ui.show(allJobs.length ? '当前没有其他可加载的任务。' : '暂无可加载任务。');
@@ -658,7 +663,7 @@ function bindJobActionEvents() {
                 : '确认清理全部任务？\n所有历史任务的中间产物与状态记录将被删除且不可恢复（不会删除 output/ 下已生成的最终输出文件）。';
             if (!(await modal.showConfirm(confirmMsg))) return;
             ui.show('正在清理任务…');
-            const exclude = hasCurrentJob ? [state.currentJobId] : [];
+            const exclude = hasCurrentJob ? [currentAttachedJobId] : [];
             const pr = await api.purgeAllJobs({ exclude });
             if (!pr.ok) { ui.show(pr.error || '清理失败'); return; }
             if (!hasCurrentJob) detachUi({ clearFile: true });
@@ -670,7 +675,7 @@ function bindJobActionEvents() {
 
     ui.elements.form.addEventListener('submit', async (e) => {
         e.preventDefault();
-        if (state.currentJobId) return;
+        if (hasUiAttachment()) return;
         if (state.createJobInFlight) return;
         detachUi({ clearFile: false });
 
@@ -716,7 +721,7 @@ function bindJobActionEvents() {
             ui.show('创建任务失败：网络或服务异常。');
         } finally {
             state.createJobInFlight = false;
-            if (!state.currentJobId) ui.refreshActionButtons(null);
+            if (!hasUiAttachment()) ui.refreshActionButtons(null);
         }
     });
 }
@@ -727,8 +732,9 @@ function bindLifecycleEvents() {
         state.pollInFlight = false;
     };
     const resumeUiObserver = (event) => {
-        if (!event.persisted || !state.currentJobId) return;
-        refreshJobOnce(state.currentJobId);
+        const jobId = attachedJobId();
+        if (!event.persisted || !jobId) return;
+        refreshJobOnce(jobId);
     };
     window.addEventListener('pagehide', stopUiObserver);
     window.addEventListener('beforeunload', stopUiObserver);
@@ -736,7 +742,7 @@ function bindLifecycleEvents() {
 }
 
 function restoreLastAttachedJob() {
-    const last = getAttachedJobId();
+    const last = restoreUiAttachment();
     if (last) attachJob(last);
 }
 

--- a/templates/static/js/state.js
+++ b/templates/static/js/state.js
@@ -1,8 +1,17 @@
 
 // State management
 
+import {
+    clearPersistedAttachment,
+    normalizeAttachedJobId,
+    persistAttachment,
+    readPersistedAttachment,
+} from './attachment.js';
+
 export const state = {
-    currentJobId: null,
+    uiAttachment: {
+        jobId: null,
+    },
     currentJobExecutionState: null,
     currentJobWorkflowPhase: null,
     currentJobWaitReason: null,
@@ -37,7 +46,6 @@ export const state = {
 };
 
 const UI_STATE_KEY = 'novel_proofer.ui_state.v1';
-const ATTACHED_JOB_KEY = 'novel_proofer.attached_job_id.v2';
 
 export const UI_STATE_FIELDS = [
     'suffix',
@@ -96,19 +104,33 @@ export function saveUiState(formElement) {
     } catch (e) {}
 }
 
-export function getAttachedJobId() {
-    try {
-        return localStorage.getItem(ATTACHED_JOB_KEY);
-    } catch (e) {
-        return null;
-    }
+export function attachedJobId() {
+    return state.uiAttachment.jobId;
 }
 
-export function setAttachedJobId(id) {
-    try {
-        if (id) localStorage.setItem(ATTACHED_JOB_KEY, id);
-        else localStorage.removeItem(ATTACHED_JOB_KEY);
-    } catch (e) {}
+export function hasUiAttachment() {
+    return !!state.uiAttachment.jobId;
+}
+
+export function attachUiToJob(jobId) {
+    const normalized = persistAttachment(localStorage, jobId);
+    state.uiAttachment.jobId = normalized;
+    return normalized;
+}
+
+export function detachUiFromJob() {
+    clearPersistedAttachment(localStorage);
+    state.uiAttachment.jobId = null;
+}
+
+export function restoreUiAttachment() {
+    const jobId = readPersistedAttachment(localStorage);
+    state.uiAttachment.jobId = jobId;
+    return jobId;
+}
+
+export function attachmentMatches(jobId) {
+    return state.uiAttachment.jobId === normalizeAttachedJobId(jobId);
 }
 
 export function saveActiveTab(tabName) {

--- a/templates/static/js/ui.js
+++ b/templates/static/js/ui.js
@@ -1,5 +1,5 @@
 
-import { state, UI_STATE_FIELDS } from './state.js';
+import { attachedJobId, state, UI_STATE_FIELDS } from './state.js';
 import { actionAvailability, primaryActionKey, snapshotLabel, snapshotTone } from './workflow.js';
 
 // DOM Elements Cache
@@ -275,7 +275,7 @@ export function renderChunksTable() {
     if (!state.chunksData || state.chunksData.length === 0) {
         elements.noChunksHint.classList.remove('hidden');
         elements.chunksTableWrap.classList.add('hidden');
-        if (state.currentJobId) {
+        if (attachedJobId()) {
             if (state.currentFilter === 'all') {
                 elements.noChunksHint.textContent = '暂无分片数据（可切换到调试信息页以加载）。';
             } else {

--- a/tests/api/test_attachment_js.py
+++ b/tests/api/test_attachment_js.py
@@ -1,0 +1,40 @@
+from __future__ import annotations
+
+import subprocess
+import textwrap
+
+
+def test_ui_attachment_helpers_are_browser_local_only() -> None:
+    script = textwrap.dedent(
+        """
+        import assert from 'node:assert/strict';
+        import {
+            ATTACHED_JOB_KEY,
+            clearPersistedAttachment,
+            normalizeAttachedJobId,
+            persistAttachment,
+            readPersistedAttachment,
+        } from './templates/static/js/attachment.js';
+
+        const store = new Map();
+        const storage = {
+            getItem: (key) => store.has(key) ? store.get(key) : null,
+            setItem: (key, value) => store.set(key, String(value)),
+            removeItem: (key) => store.delete(key),
+        };
+
+        assert.equal(normalizeAttachedJobId('  abc123  '), 'abc123');
+        assert.equal(readPersistedAttachment(storage), null);
+
+        assert.equal(persistAttachment(storage, '  job-1  '), 'job-1');
+        assert.equal(store.get(ATTACHED_JOB_KEY), 'job-1');
+        assert.equal(readPersistedAttachment(storage), 'job-1');
+
+        clearPersistedAttachment(storage);
+        assert.equal(readPersistedAttachment(storage), null);
+
+        assert.throws(() => persistAttachment(storage, '   '), /missing job_id/);
+    """
+    )
+
+    subprocess.run(["node", "--input-type=module", "-e", script], check=True)

--- a/tests/api/test_lifecycle_js.py
+++ b/tests/api/test_lifecycle_js.py
@@ -21,6 +21,23 @@ def extract_js_function(source: str, name: str) -> str:
     raise AssertionError(f"function {name} has no closing brace")
 
 
+def extract_js_block_after(source: str, needle: str) -> str:
+    start = source.index(needle)
+    brace_start = source.index("{", start)
+
+    depth = 0
+    for index in range(brace_start, len(source)):
+        char = source[index]
+        if char == "{":
+            depth += 1
+        elif char == "}":
+            depth -= 1
+            if depth == 0:
+                return source[start : index + 1]
+
+    raise AssertionError(f"block after {needle!r} has no closing brace")
+
+
 def test_browser_lifecycle_handlers_do_not_mutate_jobs() -> None:
     api_js = Path("templates/static/js/api.js").read_text(encoding="utf-8")
     main_js = Path("templates/static/js/main.js").read_text(encoding="utf-8")
@@ -40,4 +57,30 @@ def test_browser_lifecycle_handlers_do_not_mutate_jobs() -> None:
     assert re.search(r"addEventListener\(\s*['\"]beforeunload['\"]\s*,\s*stopUiObserver\s*\)", lifecycle_section)
     assert re.search(r"addEventListener\(\s*['\"]pageshow['\"]\s*,\s*resumeUiObserver\s*\)", lifecycle_section)
     assert "event.persisted" in lifecycle_section
-    assert "refreshJobOnce(state.currentJobId)" in lifecycle_section
+    assert "attachedJobId()" in lifecycle_section
+    assert "refreshJobOnce(jobId)" in lifecycle_section
+
+
+def test_restore_and_missing_job_only_change_ui_attachment() -> None:
+    main_js = Path("templates/static/js/main.js").read_text(encoding="utf-8")
+
+    restore_section = extract_js_function(main_js, "restoreLastAttachedJob")
+    assert "restoreUiAttachment()" in restore_section
+    assert "attachJob(last)" in restore_section
+    assert "api." not in restore_section
+
+    refresh_section = extract_js_function(main_js, "refreshJobOnce")
+    assert "r.status === 404" in refresh_section
+    assert "detachUi()" in refresh_section
+    assert "api.pauseJob" not in refresh_section
+    assert "api.resetJob" not in refresh_section
+
+
+def test_new_task_detaches_without_backend_mutation() -> None:
+    main_js = Path("templates/static/js/main.js").read_text(encoding="utf-8")
+
+    new_task_section = extract_js_block_after(main_js, "ui.elements.btnCancel?.addEventListener")
+    assert "detachUi({ clearFile: true })" in new_task_section
+    assert "api.pauseJob" not in new_task_section
+    assert "api.resetJob" not in new_task_section
+    assert "api.purgeAllJobs" not in new_task_section


### PR DESCRIPTION
## Summary
- add a small browser-side UiAttachment helper for persisted job attachment
- route main/ui code through explicit attachment helpers instead of `state.currentJobId`
- keep refresh/restore, missing-job detach, and new-task detach as UI-only behavior
- document the new UI attachment tests

Closes #81

## Validation
- `uv run --frozen --no-sync ruff format --check`
- `uv run --frozen --no-sync ruff check`
- `uv run --frozen --no-sync python -m mypy novel_proofer`
- `uv run --frozen --no-sync python -m pytest -q --no-cov tests/api/test_attachment_js.py tests/api/test_lifecycle_js.py tests/api/test_workflow_js.py`
- `uv run --frozen --no-sync python -m pytest -q -m "not llm_integration"`
- `uv run --frozen --no-sync python tools/export-openapi.py --check`
- `uv run --frozen --no-sync python tools/check-large-files.py`
- `node --check templates/static/js/main.js`
- `node --check templates/static/js/state.js`
- `node --check templates/static/js/attachment.js`

## Summary by Sourcery

Refactor browser UI job attachment to go through explicit attachment helpers and keep it as a local UI concern, and add tests and documentation for the new attachment and lifecycle behaviors.

Enhancements:
- Introduce a browser-side UiAttachment helper module and state wrapper to normalize, persist, restore, and clear job attachment independently of other UI state.
- Update main UI and rendering logic to rely on explicit attachment accessors instead of directly using a current job id field.

Documentation:
- Document the new UI attachment and lifecycle test cases in the testcases documentation.

Tests:
- Add Node-based tests to validate that UI attachment helpers are purely browser-local and correctly handle normalization, persistence, and error cases.
- Extend lifecycle and UI tests to ensure restore, missing-job handling, and new-task actions only adjust UI attachment without mutating backend jobs.