### PR TITLE
refactor(ui): derive settings locks from snapshot

### DIFF
--- a/docs/TESTCASES.md
+++ b/docs/TESTCASES.md
@@ -42,6 +42,13 @@
 | `tests/api/test_lifecycle_js.py::test_restore_and_missing_job_only_change_ui_attachment` | 验证页面启动恢复只读取浏览器侧 attachment 并重新 attach；已删除/不存在任务只清 UI attachment，不触发 pause/reset。 |
 | `tests/api/test_lifecycle_js.py::test_new_task_detaches_without_backend_mutation` | 验证“新任务”按钮只解除 UI attachment 与本地文件选择，不调用 pause/reset/purge 等后端任务变更。 |
 
+## tests/api/test_workflow_js.py
+
+| Test case | 说明 |
+| --- | --- |
+| `tests/api/test_workflow_js.py::test_frontend_workflow_actions_use_snapshot_commands` | 覆盖前端 action availability、primary action、状态文案与状态色调都来自 API snapshot 的命令/阶段/执行态。 |
+| `tests/api/test_workflow_js.py::test_frontend_settings_locks_use_snapshot_state` | 覆盖设置锁从 snapshot 派生：detached 不锁，process/merge/done 后锁格式设置，只有 queued/running execution 锁 LLM 设置，idle/error/retry/merge 等状态允许修改 LLM。 |
+
 ## tests/formatting/test_chunking.py
 
 | Test case | 说明 |

--- a/templates/static/js/ui.js
+++ b/templates/static/js/ui.js
@@ -417,13 +417,13 @@ export function refreshLocks(job) {
     _setFieldsDisabled(SLICE_FIELDS, locks.formatLocked);
     if (elements.sliceLockHint) {
         elements.sliceLockHint.classList.toggle('hidden', !locks.formatLocked);
-        if (locks.formatLocked) elements.sliceLockHint.textContent = locks.formatLockReason;
+        elements.sliceLockHint.textContent = locks.formatLockReason;
     }
 
     _setFieldsDisabled(LLM_FIELDS, locks.llmLocked);
     if (elements.llmLockHint) {
         elements.llmLockHint.classList.toggle('hidden', !locks.llmLocked);
-        if (locks.llmLocked) elements.llmLockHint.textContent = locks.llmLockReason;
+        elements.llmLockHint.textContent = locks.llmLockReason;
     }
 }
 

--- a/templates/static/js/ui.js
+++ b/templates/static/js/ui.js
@@ -1,6 +1,6 @@
 
 import { attachedJobId, state, UI_STATE_FIELDS } from './state.js';
-import { actionAvailability, primaryActionKey, snapshotLabel, snapshotTone } from './workflow.js';
+import { actionAvailability, primaryActionKey, settingsLockState, snapshotLabel, snapshotTone } from './workflow.js';
 
 // DOM Elements Cache
 export const elements = {};
@@ -412,20 +412,18 @@ const LLM_FIELDS = [
 ];
 
 export function refreshLocks(job) {
-    const hasJob = !!job;
-    const execution = String(job?.execution_state || '').toLowerCase();
-    const llmLocked = hasJob && ['queued', 'running'].includes(execution);
+    const locks = settingsLockState(job);
 
-    _setFieldsDisabled(SLICE_FIELDS, hasJob);
+    _setFieldsDisabled(SLICE_FIELDS, locks.formatLocked);
     if (elements.sliceLockHint) {
-        elements.sliceLockHint.classList.toggle('hidden', !hasJob);
-        if (hasJob) elements.sliceLockHint.textContent = '当前已关联任务，切片设置已锁定（要修改请先点“新任务”解除关联，或删除任务后重新创建）。';
+        elements.sliceLockHint.classList.toggle('hidden', !locks.formatLocked);
+        if (locks.formatLocked) elements.sliceLockHint.textContent = locks.formatLockReason;
     }
 
-    _setFieldsDisabled(LLM_FIELDS, llmLocked);
+    _setFieldsDisabled(LLM_FIELDS, locks.llmLocked);
     if (elements.llmLockHint) {
-        elements.llmLockHint.classList.toggle('hidden', !llmLocked);
-        if (llmLocked) elements.llmLockHint.textContent = '任务运行中，LLM 配置已锁定（暂停/出错后可修改并用于继续/重试）。';
+        elements.llmLockHint.classList.toggle('hidden', !locks.llmLocked);
+        if (locks.llmLocked) elements.llmLockHint.textContent = locks.llmLockReason;
     }
 }
 

--- a/templates/static/js/workflow.js
+++ b/templates/static/js/workflow.js
@@ -72,6 +72,24 @@ export function actionAvailability(job, { hasLocalFile = false, createJobInFligh
     };
 }
 
+export function settingsLockState(job) {
+    const view = normalizeJobState(job);
+    const formatLocked = view.hasJob && ['process', 'merge', 'done'].includes(view.workflowPhase);
+    const llmLocked = view.hasJob && isInFlight(view.executionState);
+
+    return {
+        ...view,
+        formatLocked,
+        llmLocked,
+        formatLockReason: formatLocked
+            ? '任务已完成预处理，切片与格式设置已写入当前任务。'
+            : '',
+        llmLockReason: llmLocked
+            ? '任务正在执行，LLM 设置会在暂停、出错或等待下一步时解锁。'
+            : '',
+    };
+}
+
 export function primaryActionKey(job, options = {}) {
     const availability = actionAvailability(job, options);
     if (!availability.hasJob || availability.canResumeValidate) return 'validate';

--- a/tests/api/test_workflow_js.py
+++ b/tests/api/test_workflow_js.py
@@ -103,7 +103,9 @@ def test_frontend_settings_locks_use_snapshot_state() -> None:
 
         const detached = settingsLockState(null);
         assert.equal(detached.formatLocked, false);
+        assert.equal(detached.formatLockReason, '');
         assert.equal(detached.llmLocked, false);
+        assert.equal(detached.llmLockReason, '');
 
         const readyToProcess = {
             id: 'job1',
@@ -114,8 +116,11 @@ def test_frontend_settings_locks_use_snapshot_state() -> None:
             available_commands: ['process', 'detach', 'reset'],
             progress: { done_chunks: 0, total_chunks: 2 },
         };
-        assert.equal(settingsLockState(readyToProcess).formatLocked, true);
-        assert.equal(settingsLockState(readyToProcess).llmLocked, false);
+        const readyToProcessLocks = settingsLockState(readyToProcess);
+        assert.equal(readyToProcessLocks.formatLocked, true);
+        assert.notEqual(readyToProcessLocks.formatLockReason, '');
+        assert.equal(readyToProcessLocks.llmLocked, false);
+        assert.equal(readyToProcessLocks.llmLockReason, '');
         assert.equal(actionAvailability(readyToProcess).canProcess, true);
 
         const userPaused = {
@@ -126,14 +131,30 @@ def test_frontend_settings_locks_use_snapshot_state() -> None:
         assert.equal(settingsLockState(userPaused).formatLocked, true);
         assert.equal(settingsLockState(userPaused).llmLocked, false);
 
+        const queued = {
+            ...readyToProcess,
+            execution_state: 'queued',
+            wait_reason: null,
+            available_commands: [],
+        };
+        const queuedLocks = settingsLockState(queued);
+        assert.equal(queuedLocks.formatLocked, true);
+        assert.notEqual(queuedLocks.formatLockReason, '');
+        assert.equal(queuedLocks.llmLocked, true);
+        assert.notEqual(queuedLocks.llmLockReason, '');
+        assert.equal(actionAvailability(queued).canProcess, false);
+
         const running = {
             ...readyToProcess,
             execution_state: 'running',
             wait_reason: null,
             available_commands: ['pause', 'reset'],
         };
-        assert.equal(settingsLockState(running).formatLocked, true);
-        assert.equal(settingsLockState(running).llmLocked, true);
+        const runningLocks = settingsLockState(running);
+        assert.equal(runningLocks.formatLocked, true);
+        assert.notEqual(runningLocks.formatLockReason, '');
+        assert.equal(runningLocks.llmLocked, true);
+        assert.notEqual(runningLocks.llmLockReason, '');
         assert.equal(actionAvailability(running).canProcess, false);
 
         const retryableError = {
@@ -142,9 +163,27 @@ def test_frontend_settings_locks_use_snapshot_state() -> None:
             wait_reason: null,
             available_commands: ['retry_failed', 'detach', 'reset'],
         };
-        assert.equal(settingsLockState(retryableError).formatLocked, true);
-        assert.equal(settingsLockState(retryableError).llmLocked, false);
+        const retryableErrorLocks = settingsLockState(retryableError);
+        assert.equal(retryableErrorLocks.formatLocked, true);
+        assert.notEqual(retryableErrorLocks.formatLockReason, '');
+        assert.equal(retryableErrorLocks.llmLocked, false);
+        assert.equal(retryableErrorLocks.llmLockReason, '');
         assert.equal(actionAvailability(retryableError).canRetry, true);
+
+        const done = {
+            ...readyToProcess,
+            workflow_phase: 'done',
+            wait_reason: null,
+            terminal_state: 'done',
+            available_commands: ['download', 'detach', 'reset'],
+            progress: { done_chunks: 2, total_chunks: 2 },
+        };
+        const doneLocks = settingsLockState(done);
+        assert.equal(doneLocks.formatLocked, true);
+        assert.notEqual(doneLocks.formatLockReason, '');
+        assert.equal(doneLocks.llmLocked, false);
+        assert.equal(doneLocks.llmLockReason, '');
+        assert.equal(actionAvailability(done).canProcess, false);
 
         const readyToMerge = {
             ...readyToProcess,
@@ -153,10 +192,13 @@ def test_frontend_settings_locks_use_snapshot_state() -> None:
             available_commands: ['merge', 'detach', 'reset'],
             progress: { done_chunks: 2, total_chunks: 2 },
         };
-        assert.equal(settingsLockState(readyToMerge).formatLocked, true);
-        assert.equal(settingsLockState(readyToMerge).llmLocked, false);
-        assert.equal(settingsLockState(readyToMerge).formatLockReason.includes('api/'), false);
-        assert.equal(settingsLockState(running).llmLockReason.includes('/'), false);
+        const readyToMergeLocks = settingsLockState(readyToMerge);
+        assert.equal(readyToMergeLocks.formatLocked, true);
+        assert.notEqual(readyToMergeLocks.formatLockReason, '');
+        assert.equal(readyToMergeLocks.llmLocked, false);
+        assert.equal(readyToMergeLocks.llmLockReason, '');
+        assert.equal(readyToMergeLocks.formatLockReason.includes('api/'), false);
+        assert.equal(runningLocks.llmLockReason.includes('/'), false);
         """
     )
 

--- a/tests/api/test_workflow_js.py
+++ b/tests/api/test_workflow_js.py
@@ -8,7 +8,13 @@ def test_frontend_workflow_actions_use_snapshot_commands() -> None:
     script = textwrap.dedent(
         """
         import assert from 'node:assert/strict';
-        import { actionAvailability, primaryActionKey, snapshotLabel, snapshotTone } from './templates/static/js/workflow.js';
+        import {
+            actionAvailability,
+            primaryActionKey,
+            settingsLockState,
+            snapshotLabel,
+            snapshotTone,
+        } from './templates/static/js/workflow.js';
 
         const readyToProcess = {
             id: 'job1',
@@ -83,6 +89,74 @@ def test_frontend_workflow_actions_use_snapshot_commands() -> None:
         };
         assert.equal(actionAvailability(cancelled).canDetach, false);
         assert.equal(primaryActionKey(cancelled), null);
+        """
+    )
+
+    subprocess.run(["node", "--input-type=module", "-e", script], check=True)
+
+
+def test_frontend_settings_locks_use_snapshot_state() -> None:
+    script = textwrap.dedent(
+        """
+        import assert from 'node:assert/strict';
+        import { actionAvailability, settingsLockState } from './templates/static/js/workflow.js';
+
+        const detached = settingsLockState(null);
+        assert.equal(detached.formatLocked, false);
+        assert.equal(detached.llmLocked, false);
+
+        const readyToProcess = {
+            id: 'job1',
+            workflow_phase: 'process',
+            execution_state: 'idle',
+            wait_reason: 'ready_to_process',
+            terminal_state: null,
+            available_commands: ['process', 'detach', 'reset'],
+            progress: { done_chunks: 0, total_chunks: 2 },
+        };
+        assert.equal(settingsLockState(readyToProcess).formatLocked, true);
+        assert.equal(settingsLockState(readyToProcess).llmLocked, false);
+        assert.equal(actionAvailability(readyToProcess).canProcess, true);
+
+        const userPaused = {
+            ...readyToProcess,
+            wait_reason: 'user_paused',
+            progress: { done_chunks: 1, total_chunks: 2 },
+        };
+        assert.equal(settingsLockState(userPaused).formatLocked, true);
+        assert.equal(settingsLockState(userPaused).llmLocked, false);
+
+        const running = {
+            ...readyToProcess,
+            execution_state: 'running',
+            wait_reason: null,
+            available_commands: ['pause', 'reset'],
+        };
+        assert.equal(settingsLockState(running).formatLocked, true);
+        assert.equal(settingsLockState(running).llmLocked, true);
+        assert.equal(actionAvailability(running).canProcess, false);
+
+        const retryableError = {
+            ...readyToProcess,
+            terminal_state: 'error',
+            wait_reason: null,
+            available_commands: ['retry_failed', 'detach', 'reset'],
+        };
+        assert.equal(settingsLockState(retryableError).formatLocked, true);
+        assert.equal(settingsLockState(retryableError).llmLocked, false);
+        assert.equal(actionAvailability(retryableError).canRetry, true);
+
+        const readyToMerge = {
+            ...readyToProcess,
+            workflow_phase: 'merge',
+            wait_reason: 'ready_to_merge',
+            available_commands: ['merge', 'detach', 'reset'],
+            progress: { done_chunks: 2, total_chunks: 2 },
+        };
+        assert.equal(settingsLockState(readyToMerge).formatLocked, true);
+        assert.equal(settingsLockState(readyToMerge).llmLocked, false);
+        assert.equal(settingsLockState(readyToMerge).formatLockReason.includes('api/'), false);
+        assert.equal(settingsLockState(running).llmLockReason.includes('/'), false);
         """
     )
 


### PR DESCRIPTION
## Summary
- add a pure `settingsLockState()` helper derived from the clean job snapshot
- render slice/format and LLM lock state from that helper instead of ad hoc UI checks
- lock format settings once the job reaches process/merge/done, and lock LLM settings only while execution is queued/running
- cover detached, ready-to-process, user-paused, running, retryable error, and ready-to-merge lock states

Closes #82

## Validation
- `uv run --frozen --no-sync ruff format --check`
- `uv run --frozen --no-sync ruff check`
- `uv run --frozen --no-sync python -m mypy novel_proofer`
- `uv run --frozen --no-sync python -m pytest -q --no-cov tests/api/test_workflow_js.py`
- `uv run --frozen --no-sync python -m pytest -q -m "not llm_integration"`
- `uv run --frozen --no-sync python tools/export-openapi.py --check`
- `uv run --frozen --no-sync python tools/check-large-files.py`
- `node --check templates/static/js/workflow.js`
- `node --check templates/static/js/ui.js`

## Summary by Sourcery

Derive frontend settings lock state for slice/format and LLM configuration from a new snapshot-based helper and wire it through the UI and tests.

Enhancements:
- Introduce a snapshot-derived settingsLockState helper that encapsulates format and LLM lock state and reasons based on normalized job state.
- Update the UI lock handling to use the centralized settingsLockState output for disabling fields and displaying localized lock hints.

Tests:
- Add frontend workflow JavaScript tests to cover settings lock behavior across detached, ready-to-process, user-paused, running, retryable error, and ready-to-merge states.
- Document the new workflow JavaScript test cases in TESTCASES.md, including coverage for snapshot-based action availability and settings locks.