### PR TITLE
refactor(workflow): route retry and merge through commands

### DIFF
--- a/docs/TESTCASES.md
+++ b/docs/TESTCASES.md
@@ -18,6 +18,9 @@
 | `tests/api/test_endpoints.py::test_job_id_is_normalized_to_lowercase_for_lookup` | `job_id` 大小写不敏感：服务端应在路由层将 path 参数标准化为小写后再查询任务。 |
 | `tests/api/test_endpoints.py::test_create_job_llm_enabled_requires_base_url_and_model` | LLM 配置缺失（`base_url/model` 为空）时，创建任务仍返回 `201`，但任务最终进入 `error` 状态。 |
 | `tests/api/test_endpoints.py::test_job_actions_pause_resume` | 覆盖任务动作接口：`pause/resume` 的返回值与状态流转（通过 monkeypatch 避免真实 runner 副作用）。 |
+| `tests/api/test_endpoints.py::test_retry_failed_command_schedules_only_failed_chunks` | 覆盖 retry-failed 命令边界：API 先经 workflow command 校验，再只把 failed chunk indices 传给后台 runner，不让 runner 自行猜测 pending/retrying 分片。 |
+| `tests/api/test_endpoints.py::test_merge_command_rejects_failed_or_incomplete_chunks_before_background_submit` | 覆盖 merge 命令拒绝：failed/incomplete chunks 会在 workflow command 层返回 `409`，且不会提交后台 merge execution。 |
+| `tests/api/test_endpoints.py::test_reset_active_retry_or_merge_execution_requests_delete` | 覆盖 retry/merge 执行中 reset：通过 execution registry 发送 `delete` stop 请求，并把 durable job 标记为 cancelled。 |
 | `tests/api/test_endpoints.py::test_pause_only_allowed_in_process_phase` | `pause` 仅允许在 `phase=process` 时执行；其他阶段返回 `409`。 |
 | `tests/api/test_endpoints.py::test_reset_job_deletes_job` | 覆盖 `reset`：任务会从任务列表中被删除（但不会删除 `output/` 下已生成的最终输出）。 |
 | `tests/api/test_endpoints.py::test_reset_completed_job_deletes_without_forcing_cancel` | 覆盖完成态 `reset`：按 workflow decision 直接清理删除，不额外写入 `cancelled` 状态。 |
@@ -115,6 +118,7 @@
 | `tests/test_workflow.py::test_resume_guard_selects_validate_or_process_target` | 校验 resume 会按当前 phase 选择 `validate` 或 `process` 目标。 |
 | `tests/test_workflow.py::test_retry_guard_requires_error_state_with_failed_chunks` | 校验 retry failed 只允许 error job 且存在失败分片。 |
 | `tests/test_workflow.py::test_processing_final_state_depends_only_on_chunk_states` | 校验处理阶段最终状态只由分片 error/done 汇总决定。 |
+| `tests/test_workflow.py::test_retry_failed_chunk_indices_selects_only_failed_chunks` | 校验 retry command 的目标选择只包含当前 failed chunks，不包含 pending/retrying/done。 |
 | `tests/test_workflow.py::test_merge_guard_requires_paused_merge_phase_and_complete_chunks` | 校验 merge 只允许 paused + merge phase + 分片全 done。 |
 | `tests/test_workflow.py::test_persisted_phase_invariants_are_centralized` | 校验持久化 phase/state/chunk invariants 统一由 workflow 模块暴露。 |
 | `tests/test_workflow.py::test_command_decisions_return_explicit_next_state_and_target` | 表驱动校验合法命令返回明确 next workflow state 与 resume target。 |
@@ -196,7 +200,7 @@
 | `tests/runner/test_extra_coverage.py::test_llm_worker_ratio_validation_errors` | 输出长度校验：除首 chunk 外，过短/过长输出应标记 chunk 为 error 并写入错误信息。 |
 | `tests/runner/test_extra_coverage.py::test_run_llm_for_indices_paused_cancelled_and_worker_exception` | `_run_llm_for_indices()` 收到 execution registry 的 pause/delete stop 请求时直接返回；worker 抛异常时不应导致整体失败（最终返回 done）。 |
 | `tests/runner/test_extra_coverage.py::test_run_job_cancellation_llm_outcomes_and_exception` | `run_job()` 对 registry stop 的多阶段分支（预处理/输出）与 LLM outcome（paused/cancelled）处理正确；异常应把 job 置为 error 并记录信息。 |
-| `tests/runner/test_extra_coverage.py::test_retry_failed_and_resume_paused_branches` | 覆盖 `retry_failed_chunks()/resume_paused_job()` 的缺失配置分支、无失败分支、以及 paused/cancelled outcome 分支与收尾 done 分支。 |
+| `tests/runner/test_extra_coverage.py::test_retry_failed_and_resume_paused_branches` | 覆盖 `retry_failed_chunks()/resume_paused_job()` 的缺失配置分支、显式空 retry target 错误、paused/cancelled outcome 分支与收尾 done 分支。 |
 
 ## tests/runner/test_jobs_logs.py
 
@@ -205,6 +209,7 @@
 | `tests/runner/test_jobs_logs.py::test_llm_worker_success_writes_resp_only_when_enabled` | 成功时默认不写 `resp/`；启用保留时仅写入按 index 命名的 `resp/000000.txt`，且不产生旧的 `req/`、`error/` 目录。 |
 | `tests/runner/test_jobs_logs.py::test_llm_worker_error_does_not_create_error_dir` | 失败时不创建 `error/` 目录，且 chunk 状态应为 error 并记录 `last_error_code/message`。 |
 | `tests/runner/test_jobs_logs.py::test_retry_failed_chunks_overwrites_resp` | 失败后重试应覆盖旧 `resp` 文件并最终写出合并输出，同时 job/chunk 状态收敛为 done。 |
+| `tests/runner/test_jobs_logs.py::test_retry_failed_chunks_keeps_error_when_retry_still_fails` | 覆盖 failed chunk 重试后仍失败的收敛：job 保持 process error，chunk 保持 error 并记录新错误。 |
 | `tests/runner/test_jobs_logs.py::test_resume_paused_job_overwrites_existing_resp` | 恢复暂停任务时，如已有旧 `resp`，也应被覆盖为新响应并生成最终输出。 |
 
 ## tests/runner/test_run_job.py

--- a/novel_proofer/api.py
+++ b/novel_proofer/api.py
@@ -648,7 +648,8 @@ async def retry_failed(
     retry_targets = retry_failed_chunk_indices((chunk.index, chunk.state) for chunk in st.chunk_statuses)
     if not retry_targets:
         raise HTTPException(status_code=500, detail="workflow retry targets missing")
-    previous_chunks = {chunk.index: chunk for chunk in st.chunk_statuses if chunk.index in retry_targets}
+    retry_targets_set = set(retry_targets)
+    previous_chunks = {chunk.index: chunk for chunk in st.chunk_statuses if chunk.index in retry_targets_set}
 
     _JobCommandService.apply_command_state(
         job_id,

--- a/novel_proofer/api.py
+++ b/novel_proofer/api.py
@@ -60,7 +60,13 @@ from novel_proofer.models import (
 )
 from novel_proofer.runner import merge_outputs, resume_paused_job, retry_failed_chunks, run_job
 from novel_proofer.states import ChunkState, JobCommand, JobPhase, JobState, WaitReason
-from novel_proofer.workflow import CommandDecision, ResumeTarget, decide_command, resume_decision
+from novel_proofer.workflow import (
+    CommandDecision,
+    ResumeTarget,
+    decide_command,
+    resume_decision,
+    retry_failed_chunk_indices,
+)
 from novel_proofer.workflow_context import workflow_context_for_job
 
 logger = logging.getLogger(__name__)
@@ -116,6 +122,18 @@ class _JobCommandService:
         if st is None:
             raise HTTPException(status_code=500, detail="job store error")
         return st
+
+    @staticmethod
+    def apply_command_state(job_id: str, decision: CommandDecision, **updates: Any) -> None:
+        if decision.next_state is None:
+            raise HTTPException(status_code=500, detail="workflow command state missing")
+        GLOBAL_JOBS.update(
+            job_id,
+            state=decision.next_state.state,
+            phase=decision.next_state.phase,
+            wait_reason=decision.next_state.wait_reason,
+            **updates,
+        )
 
     @staticmethod
     def cleanup_failed_new_job(job_id: str) -> None:
@@ -576,15 +594,7 @@ async def resume_job(
     if st is None:
         raise HTTPException(status_code=404, detail="job not found")
     resume_command = _require_resume_workflow(st)
-    if resume_command.next_state is None:
-        raise HTTPException(status_code=500, detail="workflow command state missing")
-    GLOBAL_JOBS.update(
-        job_id,
-        state=resume_command.next_state.state,
-        phase=resume_command.next_state.phase,
-        wait_reason=resume_command.next_state.wait_reason,
-        finished_at=None,
-    )
+    _JobCommandService.apply_command_state(job_id, resume_command, finished_at=None)
 
     llm = _llm_from_options(body.llm or LLMOptions())
     prev_llm_model = st.last_llm_model
@@ -631,39 +641,65 @@ async def retry_failed(
     st = GLOBAL_JOBS.get(job_id)
     if st is None:
         raise HTTPException(status_code=404, detail="job not found")
-    _require_workflow_command(st, JobCommand.RETRY_FAILED)
-
-    failed = [c.index for c in st.chunk_statuses if c.state == ChunkState.ERROR]
+    retry_decision = _require_workflow_command(st, JobCommand.RETRY_FAILED)
 
     llm = _llm_from_options(body.llm or LLMOptions())
     prev_llm_model = st.last_llm_model
+    retry_targets = retry_failed_chunk_indices((chunk.index, chunk.state) for chunk in st.chunk_statuses)
+    if not retry_targets:
+        raise HTTPException(status_code=500, detail="workflow retry targets missing")
+    previous_chunks = {chunk.index: chunk for chunk in st.chunk_statuses if chunk.index in retry_targets}
 
-    # Important: flip the visible job/chunk states before starting the worker thread, otherwise
-    # clients may poll and immediately "bounce" back to the error UI state.
-    GLOBAL_JOBS.update(
-        job_id, state=JobState.QUEUED, phase=JobPhase.PROCESS, finished_at=None, error=None, last_llm_model=llm.model
+    _JobCommandService.apply_command_state(
+        job_id,
+        retry_decision,
+        finished_at=None,
+        error=None,
+        last_llm_model=llm.model,
     )
-    for i in failed:
+    for i in retry_targets:
         GLOBAL_JOBS.update_chunk(
             job_id,
             i,
             state=ChunkState.PENDING,
             started_at=None,
             finished_at=None,
+            last_error_code=None,
+            last_error_message=None,
+            llm_model=llm.model,
+            input_chars=None,
+            output_chars=None,
         )
 
     def _rollback_retry_state() -> None:
         GLOBAL_JOBS.update(
-            job_id, state=JobState.ERROR, finished_at=st.finished_at, error=st.error, last_llm_model=prev_llm_model
+            job_id,
+            state=st.state,
+            phase=st.phase,
+            wait_reason=st.wait_reason,
+            finished_at=st.finished_at,
+            error=st.error,
+            last_llm_model=prev_llm_model,
         )
-        for i in failed:
-            GLOBAL_JOBS.update_chunk(job_id, i, state=ChunkState.ERROR)
+        for i, chunk in previous_chunks.items():
+            GLOBAL_JOBS.update_chunk(
+                job_id,
+                i,
+                state=chunk.state,
+                started_at=chunk.started_at,
+                finished_at=chunk.finished_at,
+                last_error_code=chunk.last_error_code,
+                last_error_message=chunk.last_error_message,
+                llm_model=chunk.llm_model,
+                input_chars=chunk.input_chars,
+                output_chars=chunk.output_chars,
+            )
 
     _JobCommandService.submit_background(
         job_id=job_id,
         command=JobCommand.RETRY_FAILED,
         fn=retry_failed_chunks,
-        args=(job_id, llm),
+        args=(job_id, llm, retry_targets),
         on_submit_failure=_rollback_retry_state,
     )
 
@@ -678,14 +714,10 @@ async def merge_job(
     if st is None:
         raise HTTPException(status_code=404, detail="job not found")
     merge_decision = _require_workflow_command(st, JobCommand.MERGE)
-    if merge_decision.next_state is None:
-        raise HTTPException(status_code=500, detail="workflow command state missing")
 
-    GLOBAL_JOBS.update(
+    _JobCommandService.apply_command_state(
         job_id,
-        state=merge_decision.next_state.state,
-        phase=merge_decision.next_state.phase,
-        wait_reason=merge_decision.next_state.wait_reason,
+        merge_decision,
         finished_at=None,
     )
 

--- a/novel_proofer/runner.py
+++ b/novel_proofer/runner.py
@@ -25,6 +25,7 @@ from novel_proofer.workflow import (
     ProcessingFinalState,
     WorkflowEvent,
     WorkflowState,
+    WorkflowTransitionError,
     processing_final_state,
     require_event,
 )
@@ -685,7 +686,11 @@ def run_job(job_id: str, input_path: Path, fmt: FormatConfig, llm: LLMConfig) ->
         GLOBAL_JOBS.update(job_id, state=JobState.ERROR, finished_at=time.time(), error=str(e))
 
 
-def retry_failed_chunks(job_id: str, llm: LLMConfig) -> None:
+def retry_failed_chunks(job_id: str, llm: LLMConfig, target_indices: tuple[int, ...]) -> None:
+    targets = tuple(int(index) for index in target_indices)
+    if not targets:
+        raise ValueError("retry target indices are required")
+
     st = GLOBAL_JOBS.get(job_id)
     if st is None:
         return
@@ -708,12 +713,9 @@ def retry_failed_chunks(job_id: str, llm: LLMConfig) -> None:
         return
 
     total = len(st.chunk_statuses)
-    targets = [
-        c.index for c in st.chunk_statuses if c.state in {ChunkState.ERROR, ChunkState.PENDING, ChunkState.RETRYING}
-    ]
-    if not targets:
-        _finalize_processing(job_id, total, "some chunks still failed; update LLM config and retry again")
-        return
+    for index in targets:
+        if index < 0 or index >= total:
+            raise ValueError(f"retry target index out of range: {index}")
 
     GLOBAL_JOBS.update(
         job_id, state=JobState.QUEUED, phase=JobPhase.PROCESS, finished_at=None, error=None, last_llm_model=llm.model
@@ -730,7 +732,7 @@ def retry_failed_chunks(job_id: str, llm: LLMConfig) -> None:
             output_chars=None,
         )
 
-    outcome = _run_llm_for_indices(job_id, targets, work_dir, llm)
+    outcome = _run_llm_for_indices(job_id, list(targets), work_dir, llm)
     if outcome == "cancelled" or _delete_requested(job_id):
         _mark_reset_requested(job_id, phase=JobPhase.PROCESS)
         return
@@ -813,26 +815,11 @@ def merge_outputs(job_id: str, *, cleanup_debug_dir: bool | None = None) -> None
     out_path = Path(st.output_path)
     total = len(st.chunk_statuses)
 
-    if any(c.state == ChunkState.ERROR for c in st.chunk_statuses):
-        GLOBAL_JOBS.update(
-            job_id,
-            state=JobState.ERROR,
-            phase=JobPhase.PROCESS,
-            finished_at=time.time(),
-            error="cannot merge: chunks failed",
-        )
+    try:
+        next_state = _workflow_event_state(st, WorkflowEvent.MERGE_STARTED)
+    except WorkflowTransitionError as e:
+        GLOBAL_JOBS.update(job_id, state=JobState.ERROR, phase=st.phase, finished_at=time.time(), error=str(e))
         return
-    if any(c.state != ChunkState.DONE for c in st.chunk_statuses):
-        GLOBAL_JOBS.update(
-            job_id,
-            state=JobState.ERROR,
-            phase=JobPhase.MERGE,
-            finished_at=time.time(),
-            error="cannot merge: chunks not complete",
-        )
-        return
-
-    next_state = _workflow_event_state(st, WorkflowEvent.MERGE_STARTED)
     GLOBAL_JOBS.update(
         job_id,
         state=next_state.state,

--- a/novel_proofer/workflow.py
+++ b/novel_proofer/workflow.py
@@ -366,6 +366,8 @@ def decide_command(context: WorkflowContext, command: JobCommand | str) -> Comma
             return _reject(cmd, WorkflowRejectionCode.NOT_PAUSED, f"job is not paused (state={state.value})")
         if phase != JobPhase.MERGE:
             return _reject(cmd, WorkflowRejectionCode.INVALID_PHASE, f"job is not ready to merge (phase={phase.value})")
+        if context.chunks.has_failed:
+            return _reject(cmd, WorkflowRejectionCode.FAILED_CHUNKS, "job is not ready to merge (chunks failed)")
         if not context.chunks.all_done:
             return _reject(
                 cmd, WorkflowRejectionCode.CHUNKS_INCOMPLETE, "job is not ready to merge (chunks incomplete)"
@@ -499,6 +501,8 @@ def apply_event(context: WorkflowContext, event: WorkflowEvent | str) -> EventTr
             return _event_reject(evt, WorkflowRejectionCode.CANCELLED, "job is cancelled")
         if state not in {JobState.PAUSED, JobState.QUEUED, JobState.RUNNING}:
             return _event_reject(evt, WorkflowRejectionCode.INVALID_STATE, f"merge cannot start in state={state.value}")
+        if context.chunks.has_failed:
+            return _event_reject(evt, WorkflowRejectionCode.FAILED_CHUNKS, "merge chunks failed")
         if not context.chunks.all_done:
             return _event_reject(evt, WorkflowRejectionCode.CHUNKS_INCOMPLETE, "merge chunks are incomplete")
         return EventTransition.allow(evt, WorkflowState(JobState.RUNNING, JobPhase.MERGE))
@@ -508,6 +512,8 @@ def apply_event(context: WorkflowContext, event: WorkflowEvent | str) -> EventTr
             return _event_reject(
                 evt, WorkflowRejectionCode.INVALID_PHASE, f"merge cannot complete in phase={phase.value}"
             )
+        if context.chunks.has_failed:
+            return _event_reject(evt, WorkflowRejectionCode.FAILED_CHUNKS, "merge chunks failed")
         if not context.chunks.all_done:
             return _event_reject(evt, WorkflowRejectionCode.CHUNKS_INCOMPLETE, "merge chunks are incomplete")
         return EventTransition.allow(evt, WorkflowState(JobState.DONE, JobPhase.DONE))
@@ -593,6 +599,10 @@ def processing_final_state(chunks: Iterable[ChunkState | str]) -> ProcessingFina
     if any(chunk == ChunkState.ERROR for chunk in chunk_states):
         return ProcessingFinalState.ERROR
     return ProcessingFinalState.READY_TO_MERGE
+
+
+def retry_failed_chunk_indices(chunks: Iterable[tuple[int, ChunkState | str]]) -> tuple[int, ...]:
+    return tuple(int(index) for index, state in chunks if ChunkState(state) == ChunkState.ERROR)
 
 
 def validate_job_phase_invariants(

--- a/tests/api/test_endpoints.py
+++ b/tests/api/test_endpoints.py
@@ -334,6 +334,117 @@ def test_job_actions_pause_resume(monkeypatch: pytest.MonkeyPatch):
         GLOBAL_JOBS.delete(job2.job_id)
 
 
+def test_retry_failed_command_schedules_only_failed_chunks(monkeypatch: pytest.MonkeyPatch) -> None:
+    client = TestClient(api.app)
+    captured: dict[str, object] = {}
+
+    def fake_submit(job_id: str, command: object, fn: object, *args: object, **kwargs: object) -> None:
+        captured["job_id"] = job_id
+        captured["command"] = command
+        captured["fn"] = fn
+        captured["args"] = args
+        captured["kwargs"] = kwargs
+
+    monkeypatch.setattr(api, "submit_background_job", fake_submit)
+
+    job = GLOBAL_JOBS.create("in.txt", "out.txt", total_chunks=0)
+    try:
+        GLOBAL_JOBS.update(job.job_id, phase="process")
+        GLOBAL_JOBS.init_chunks(job.job_id, total_chunks=3)
+        GLOBAL_JOBS.update_chunk(job.job_id, 0, state="done")
+        GLOBAL_JOBS.update_chunk(job.job_id, 1, state="error", last_error_message="bad")
+        GLOBAL_JOBS.update(job.job_id, state="error", error="some chunks failed")
+
+        r = client.post(
+            f"/api/v1/jobs/{job.job_id}/retry-failed",
+            json={"llm": {"base_url": "http://example.com", "model": "retry-model"}},
+        )
+
+        assert r.status_code == 200, r.text
+        assert captured["job_id"] == job.job_id
+        assert captured["command"] == "retry_failed"
+        assert captured["fn"] is api.retry_failed_chunks
+        args = captured["args"]
+        assert isinstance(args, tuple)
+        assert args[0] == job.job_id
+        assert args[2] == (1,)
+
+        st = GLOBAL_JOBS.get(job.job_id)
+        assert st is not None
+        assert st.state == "queued"
+        assert st.phase == "process"
+        assert st.last_llm_model == "retry-model"
+        assert [c.state for c in st.chunk_statuses] == ["done", "pending", "pending"]
+    finally:
+        GLOBAL_JOBS.delete(job.job_id)
+
+
+@pytest.mark.parametrize(
+    ("chunk_states", "expected_detail"),
+    [
+        (["done", "error"], "job is not ready to merge (chunks failed)"),
+        (["done", "pending"], "job is not ready to merge (chunks incomplete)"),
+    ],
+)
+def test_merge_command_rejects_failed_or_incomplete_chunks_before_background_submit(
+    monkeypatch: pytest.MonkeyPatch, chunk_states: list[str], expected_detail: str
+) -> None:
+    client = TestClient(api.app)
+    submitted = False
+
+    def fake_submit(*_args: object, **_kwargs: object) -> None:
+        nonlocal submitted
+        submitted = True
+
+    monkeypatch.setattr(api, "submit_background_job", fake_submit)
+
+    job = GLOBAL_JOBS.create("in.txt", "out.txt", total_chunks=0)
+    try:
+        GLOBAL_JOBS.init_chunks(job.job_id, total_chunks=len(chunk_states))
+        for index, state in enumerate(chunk_states):
+            GLOBAL_JOBS.update_chunk(job.job_id, index, state=state)
+        GLOBAL_JOBS.update(job.job_id, state="paused", phase="merge", wait_reason="ready_to_merge")
+
+        r = client.post(f"/api/v1/jobs/{job.job_id}/merge", json={"cleanup_debug_dir": True})
+
+        assert r.status_code == 409, r.text
+        assert expected_detail in r.text
+        assert submitted is False
+        st = GLOBAL_JOBS.get(job.job_id)
+        assert st is not None
+        assert st.state == "paused"
+        assert st.phase == "merge"
+    finally:
+        GLOBAL_JOBS.delete(job.job_id)
+
+
+@pytest.mark.parametrize(
+    ("command", "phase"),
+    [
+        ("retry_failed", "process"),
+        ("merge", "merge"),
+    ],
+)
+def test_reset_active_retry_or_merge_execution_requests_delete(command: str, phase: str) -> None:
+    client = TestClient(api.app)
+    job = GLOBAL_JOBS.create("in.txt", "out.txt", total_chunks=0)
+    execution = GLOBAL_EXECUTIONS.begin(job.job_id, command)
+    try:
+        GLOBAL_JOBS.update(job.job_id, state="queued", phase=phase)
+
+        r = client.post(f"/api/v1/jobs/{job.job_id}/reset")
+
+        assert r.status_code == 200, r.text
+        assert GLOBAL_EXECUTIONS.stop_reason(job.job_id) == "delete"
+        st = GLOBAL_JOBS.get(job.job_id)
+        assert st is not None
+        assert st.state == "cancelled"
+        assert st.phase == phase
+    finally:
+        GLOBAL_EXECUTIONS.finish(execution.attempt_id)
+        GLOBAL_JOBS.delete(job.job_id)
+
+
 def test_job_snapshot_contract_covers_running_user_paused_and_cancelled() -> None:
     client = TestClient(api.app)
     job = GLOBAL_JOBS.create("in.txt", "out.txt", total_chunks=0)

--- a/tests/runner/test_extra_coverage.py
+++ b/tests/runner/test_extra_coverage.py
@@ -372,13 +372,13 @@ def test_run_job_cancellation_llm_outcomes_and_exception(monkeypatch: pytest.Mon
 def test_retry_failed_and_resume_paused_branches(monkeypatch: pytest.MonkeyPatch) -> None:
     llm = LLMConfig(base_url="http://example.com", model="m", max_concurrency=1)
 
-    runner.retry_failed_chunks("missing", llm)
+    runner.retry_failed_chunks("missing", llm, (0,))
     runner.resume_paused_job("missing", llm)
 
     # Missing work_dir/output_path.
     job_id = GLOBAL_JOBS.create("in.txt", "out.txt", total_chunks=0).job_id
     try:
-        runner.retry_failed_chunks(job_id, llm)
+        runner.retry_failed_chunks(job_id, llm, (0,))
         runner.resume_paused_job(job_id, llm)
         st = GLOBAL_JOBS.get(job_id)
         assert st is not None and st.state == "error"
@@ -394,33 +394,15 @@ def test_retry_failed_and_resume_paused_branches(monkeypatch: pytest.MonkeyPatch
             GLOBAL_JOBS.update(
                 job2_id, work_dir=str(base / "w1"), output_path=str(base / "o1.txt"), cleanup_debug_dir=False
             )
-            runner.retry_failed_chunks(job2_id, llm)
+            runner.retry_failed_chunks(job2_id, llm, (0,))
             runner.resume_paused_job(job2_id, llm)
             st = GLOBAL_JOBS.get(job2_id)
             assert st is not None and st.state == "error"
         finally:
             GLOBAL_JOBS.delete(job2_id)
 
-        # No failed chunks -> finalize to merge-ready.
-        job3_id = GLOBAL_JOBS.create("in.txt", "out.txt", total_chunks=1).job_id
-        try:
-            out_path = base / "o2.txt"
-            out_path.write_text("x", encoding="utf-8")
-            GLOBAL_JOBS.update(
-                job3_id,
-                phase="process",
-                work_dir=str(base / "w2"),
-                output_path=str(out_path),
-                cleanup_debug_dir=False,
-            )
-            GLOBAL_JOBS.init_chunks(job3_id, total_chunks=1)
-            GLOBAL_JOBS.update_chunk(job3_id, 0, state="done")
-            runner.retry_failed_chunks(job3_id, llm)
-            st = GLOBAL_JOBS.get(job3_id)
-            assert st is not None and st.state == "paused"
-            assert getattr(st, "phase", None) == "merge"
-        finally:
-            GLOBAL_JOBS.delete(job3_id)
+        with pytest.raises(ValueError, match="retry target indices are required"):
+            runner.retry_failed_chunks("missing", llm, ())
 
         # Outcome paused/cancelled branches.
         job4_id = GLOBAL_JOBS.create("in.txt", "out.txt", total_chunks=1).job_id
@@ -431,7 +413,7 @@ def test_retry_failed_and_resume_paused_branches(monkeypatch: pytest.MonkeyPatch
             GLOBAL_JOBS.init_chunks(job4_id, total_chunks=1)
             GLOBAL_JOBS.update_chunk(job4_id, 0, state="error", last_error_message="x")
             monkeypatch.setattr(runner, "_run_llm_for_indices", lambda *a, **k: "paused")
-            runner.retry_failed_chunks(job4_id, llm)
+            runner.retry_failed_chunks(job4_id, llm, (0,))
             st = GLOBAL_JOBS.get(job4_id)
             assert st is not None and st.state == "paused"
             assert getattr(st, "phase", None) == "process"
@@ -446,7 +428,7 @@ def test_retry_failed_and_resume_paused_branches(monkeypatch: pytest.MonkeyPatch
             GLOBAL_JOBS.init_chunks(job5_id, total_chunks=1)
             GLOBAL_JOBS.update_chunk(job5_id, 0, state="error", last_error_message="x")
             monkeypatch.setattr(runner, "_run_llm_for_indices", lambda *a, **k: "cancelled")
-            runner.retry_failed_chunks(job5_id, llm)
+            runner.retry_failed_chunks(job5_id, llm, (0,))
             st = GLOBAL_JOBS.get(job5_id)
             assert st is not None and st.state == "cancelled"
         finally:

--- a/tests/runner/test_jobs_logs.py
+++ b/tests/runner/test_jobs_logs.py
@@ -154,7 +154,7 @@ def test_retry_failed_chunks_overwrites_resp(monkeypatch: pytest.MonkeyPatch) ->
             runner._llm_worker(job_id, 0, work_dir, cfg, write_llm_resp=False)
             assert (work_dir / "resp" / "000000.txt").read_text(encoding="utf-8") == "RAW-FAIL"
 
-            runner.retry_failed_chunks(job_id, cfg)
+            runner.retry_failed_chunks(job_id, cfg, (0,))
 
             _assert_no_legacy_log_dirs(work_dir)
             _assert_resp_files(work_dir, expect=True)
@@ -171,6 +171,47 @@ def test_retry_failed_chunks_overwrites_resp(monkeypatch: pytest.MonkeyPatch) ->
             assert st2 is not None
             assert st2.state == "done"
             assert out_path.read_text(encoding="utf-8") == "修正后内容\n"
+        finally:
+            GLOBAL_JOBS.delete(job_id)
+
+
+def test_retry_failed_chunks_keeps_error_when_retry_still_fails(monkeypatch: pytest.MonkeyPatch) -> None:
+    def fake_call_llm_text_resilient_with_meta_and_raw(
+        cfg: LLMConfig,
+        input_text: str,
+        *,
+        should_stop=None,
+        on_retry=None,
+    ):
+        return LLMTextResult(text="", raw_text="RAW-FAIL"), 0, None, None
+
+    monkeypatch.setattr(
+        runner, "call_llm_text_resilient_with_meta_and_raw", fake_call_llm_text_resilient_with_meta_and_raw
+    )
+
+    with tempfile.TemporaryDirectory() as td:
+        work_dir = Path(td) / "work"
+        out_path = Path(td) / "final.txt"
+        (work_dir / "pre").mkdir(parents=True, exist_ok=True)
+        (work_dir / "pre" / "000000.txt").write_text("原始内容\n", encoding="utf-8")
+
+        job = GLOBAL_JOBS.create("in.txt", "out.txt", total_chunks=1)
+        job_id = job.job_id
+        try:
+            GLOBAL_JOBS.init_chunks(job_id, total_chunks=1)
+            GLOBAL_JOBS.update(job_id, work_dir=str(work_dir), output_path=str(out_path), cleanup_debug_dir=False)
+            GLOBAL_JOBS.update_chunk(job_id, 0, state="error", last_error_message="old failure")
+            cfg = LLMConfig(base_url="http://example.com", model="m", max_concurrency=1)
+
+            runner.retry_failed_chunks(job_id, cfg, (0,))
+
+            st = GLOBAL_JOBS.get(job_id)
+            assert st is not None
+            assert st.state == "error"
+            assert st.phase == "process"
+            assert "some chunks still failed" in (st.error or "")
+            assert st.chunk_statuses[0].state == "error"
+            assert "LLM output empty" in (st.chunk_statuses[0].last_error_message or "")
         finally:
             GLOBAL_JOBS.delete(job_id)
 

--- a/tests/test_workflow.py
+++ b/tests/test_workflow.py
@@ -23,6 +23,7 @@ from novel_proofer.workflow import (
     require_command,
     require_event,
     resume_decision,
+    retry_failed_chunk_indices,
     validate_job_phase_invariants,
 )
 
@@ -79,6 +80,18 @@ def test_processing_final_state_depends_only_on_chunk_states() -> None:
     assert ready == ProcessingFinalState.READY_TO_MERGE
 
 
+def test_retry_failed_chunk_indices_selects_only_failed_chunks() -> None:
+    assert retry_failed_chunk_indices(
+        [
+            (0, ChunkState.DONE),
+            (1, ChunkState.ERROR),
+            (2, ChunkState.PENDING),
+            (3, ChunkState.RETRYING),
+            (4, "error"),
+        ]
+    ) == (1, 4)
+
+
 def test_merge_guard_requires_paused_merge_phase_and_complete_chunks() -> None:
     ok = can_merge(JobState.PAUSED, JobPhase.MERGE, [ChunkState.DONE, ChunkState.DONE])
     assert ok.allowed is True
@@ -94,6 +107,10 @@ def test_merge_guard_requires_paused_merge_phase_and_complete_chunks() -> None:
     incomplete = can_merge(JobState.PAUSED, JobPhase.MERGE, [ChunkState.DONE, ChunkState.PENDING])
     assert incomplete.allowed is False
     assert incomplete.reason == "job is not ready to merge (chunks incomplete)"
+
+    failed = can_merge(JobState.PAUSED, JobPhase.MERGE, [ChunkState.DONE, ChunkState.ERROR])
+    assert failed.allowed is False
+    assert failed.reason == "job is not ready to merge (chunks failed)"
 
 
 def test_persisted_phase_invariants_are_centralized() -> None:
@@ -205,6 +222,17 @@ def test_command_decisions_return_explicit_next_state_and_target(
             JobCommand.RETRY_FAILED,
             WorkflowRejectionCode.NO_FAILED_CHUNKS,
             "no failed chunks to retry",
+        ),
+        (
+            WorkflowContext.from_values(
+                state=JobState.PAUSED,
+                phase=JobPhase.MERGE,
+                wait_reason=WaitReason.READY_TO_MERGE,
+                chunks=[ChunkState.DONE, ChunkState.ERROR],
+            ),
+            JobCommand.MERGE,
+            WorkflowRejectionCode.FAILED_CHUNKS,
+            "job is not ready to merge (chunks failed)",
         ),
         (
             WorkflowContext.from_values(
@@ -386,6 +414,16 @@ def test_workflow_events_are_table_driven(
             WorkflowEvent.MERGE_STARTED,
             WorkflowRejectionCode.INVALID_PHASE,
             "merge cannot start in phase=process",
+        ),
+        (
+            WorkflowContext.from_values(
+                state=JobState.QUEUED,
+                phase=JobPhase.MERGE,
+                chunks=[ChunkState.DONE, ChunkState.ERROR],
+            ),
+            WorkflowEvent.MERGE_STARTED,
+            WorkflowRejectionCode.FAILED_CHUNKS,
+            "merge chunks failed",
         ),
     ],
 )


### PR DESCRIPTION
## Summary
- derive retry-failed targets from the workflow command boundary and pass explicit chunk indices to the runner
- make retry and merge durable state updates use the shared command-decision application path
- make merge distinguish failed chunks from incomplete chunks through typed workflow rejections
- remove runner-side retry target guessing and cover retry/merge/reset command behavior

Closes #83

## Validation
- `uv run --frozen --no-sync ruff format --check`
- `uv run --frozen --no-sync ruff check`
- `uv run --frozen --no-sync python -m mypy novel_proofer`
- `uv run --frozen --no-sync python -m pytest -q -m "not llm_integration"`
- `uv run --frozen --no-sync python tools/export-openapi.py --check`
- `uv run --frozen --no-sync python tools/check-large-files.py`
- `node --check templates/static/js/workflow.js`
- `node --check templates/static/js/main.js`
- `node --check templates/static/js/ui.js`

## Note
- `uv run --frozen --no-sync python -m pytest -q` was also attempted; the five live `llm_integration` cases failed because the external model returned failed chunks, while the deterministic suite passed.

## Summary by Sourcery

Route retry-failed and merge operations through the workflow command path and make the runner consume explicit retry targets instead of inferring them.

Enhancements:
- Centralize application of workflow command state transitions in the API via a shared helper used by resume, retry-failed, and merge.
- Make merge commands and events distinguish between failed and merely incomplete chunks using typed workflow rejections, updating job error messages accordingly.
- Require explicit retry target indices in the runner, validating bounds and propagating workflow-derived retry sets down to the background worker.
- Preserve prior job and chunk error details when a retry still fails, while rolling back state if background retry submission fails.

Tests:
- Add API tests covering retry-failed scheduling of only failed chunks, merge pre-submit rejections for failed/incomplete chunks, and reset behavior while retry/merge executions are active.
- Extend workflow tests to cover retry target selection, merge guards for failed chunks, and typed rejections for illegal merge events.
- Update runner tests to exercise explicit retry targets, error-preserving retry failures, empty-target validation, and outcome branches for paused/cancelled retries.
- Document the new and updated test coverage in TESTCASES.md for API, workflow, and runner behaviors.